### PR TITLE
Add extended pipeline with Mac-friendly tuning

### DIFF
--- a/extra_pipeline.py
+++ b/extra_pipeline.py
@@ -50,6 +50,8 @@ NEWSAPI_KEY = "YOUR_NEWSAPI_KEY_HERE"  # From newsapi.org
 QUANDL_KEY = "YOUR_QUANDL_KEY_HERE"  # From nasdaq.com/data-link (free tier)
 FRED_API_KEY = "YOUR_FRED_API_KEY_HERE"  # From api.stlouisfed.org
 WORLD_BANK_API = "https://api.worldbank.org/v2"  # No key needed
+FINNHUB_KEY = "YOUR_FINNHUB_KEY_HERE"  # Free at finnhub.io
+POLYGON_KEY = "YOUR_POLYGON_KEY_HERE"  # Free at polygon.io
 DB_FILE = "super_db.db"
 ACTOR_ID = "kaitoeasyapi/twitter-x-data-tweet-scraper-pay-per-result-cheapest"
 USERNAMES = ["onchainlens", "unipcs", "stalkchain", "elonmusk", "example2"]  # Include tracking accounts
@@ -69,6 +71,11 @@ ECONOMIC_SERIES = ['GDP', 'UNRATE', 'CPIAUCSL']  # FRED series: GDP, Unemploymen
 NEWS_KEYWORDS = ['bitcoin', 'ethereum', 'crypto regulation']  # For NewsAPI
 QUANDL_DATASETS = ['USTREASURY/YIELD', 'FRED/GDP']  # Free datasets
 WORLD_BANK_INDICATORS = ['NY.GDP.MKTP.CD', 'SL.UEM.TOTL.ZS']  # GDP, Unemployment
+ALPHA_ECON_SERIES = ['GDP', 'UNRATE', 'CPIAUCSL', 'FEDFUNDS', 'INDPRO', 'PCE', 'RSXFS']  # Expanded Alpha/FRED
+FINNHUB_SYMBOLS = ['AAPL', 'TSLA', 'BTC-USD', 'ETH-USD']  # For fundamentals
+POLYGON_TICKERS = ['AAPL', 'TSLA', 'X:BTCUSD', 'X:ETHUSD']  # Stocks/crypto
+FRED_SERIES = ['GDP', 'UNRATE', 'CPIAUCSL', 'FEDFUNDS', 'INDPRO', 'PCE', 'RSXFS', 'WALCL', 'M2SL']  # Expanded
+COINGECKO_CRYPTOS = ['bitcoin', 'ethereum', 'solana', 'ripple', 'cardano', 'dogecoin', 'polkadot', 'chainlink', 'uniswap', 'litecoin']  # Expanded
 
 # ML Models
 sentiment_analyzer = pipeline("sentiment-analysis", model="distilbert-base-uncased-finetuned-sst-2-english")
@@ -94,12 +101,168 @@ def compute_vibe(sentiment_label, sentiment_score, likes, retweets, replies):
     else: vibe_label = "Negative/Low Engagement"
     return vibe_score, vibe_label
 
+def compute_sentiment(text):
+    if not text or not isinstance(text, str):
+        logging.warning("Invalid text for sentiment, returning default")
+        return "NEUTRAL", 0.5
+    try:
+        result = sentiment_analyzer(text[:512])[0]
+        return result['label'], result['score']
+    except Exception as e:
+        logging.error(f"Sentiment error: {e}")
+        return "NEUTRAL", 0.5
+
+def analyze_visual(image_url, tweet_text):
+    try:
+        response = requests.get(image_url, stream=True)
+        if response.status_code == 200:
+            from PIL import Image
+            from io import BytesIO
+            img = Image.open(BytesIO(response.content))
+            width, height = img.size
+            analysis = f"Visual analysis: Image {width}x{height}; potential graph in '{tweet_text[:50]}...'"
+        else:
+            analysis = "Visual analysis: Unable to download image"
+    except Exception as e:
+        logging.error(f"Visual analysis error: {e}")
+        analysis = "Visual analysis: Error"
+    return analysis
+
+def send_for_approval(bot, tweet_id, tweet_text, analysis):
+    try:
+        markup = InlineKeyboardMarkup([
+            [InlineKeyboardButton("Approve", callback_data=f"approve_{tweet_id}"),
+             InlineKeyboardButton("Deny", callback_data=f"deny_{tweet_id}")]
+        ])
+        bot.send_message(chat_id=TELEGRAM_CHAT_ID,
+                         text=f"Tweet ID: {tweet_id}\nText: {tweet_text[:200]}\nAnalysis: {analysis}",
+                         reply_markup=markup)
+    except Exception as e:
+        logging.error(f"Telegram send error: {e}")
+
+def retry_func(func, *args, **kwargs):
+    for attempt in range(MAX_RETRIES):
+        try:
+            return func(*args, **kwargs)
+        except Exception as e:
+            if attempt == MAX_RETRIES - 1:
+                logging.error(f"Max retries exceeded for {func.__name__}: {e}")
+                raise
+            backoff = BASE_BACKOFF * (2 ** attempt) + random.uniform(0, 1)
+            logging.warning(f"Retry {attempt+1} for {func.__name__}: {e}. Sleeping {backoff:.2f}s")
+            time.sleep(backoff)
+
+def monitor_costs(client):
+    try:
+        usage = client.user().get()['usage']
+        used_credits = usage.get('platformUsageCredits', 0)
+        percent = used_credits / MONTHLY_CREDITS
+        if percent > CREDIT_THRESHOLD:
+            bot.send_message(chat_id=TELEGRAM_CHAT_ID,
+                             text=f"Warning: {percent*100:.1f}% credits used ({used_credits:.2f}/{MONTHLY_CREDITS}) - Pause if needed")
+        return used_credits
+    except Exception as e:
+        logging.error(f"Cost monitoring error: {e}")
+        return 0
+
+def approval_handler(update, context):
+    query = update.callback_query
+    data = query.data
+    tweet_id = data.split('_')[1]
+    approved = 1 if data.startswith('approve') else 0
+    with db_lock:
+        conn = sqlite3.connect(DB_FILE)
+        update_tweet_analysis(conn, tweet_id, None, approved)
+        conn.close()
+    query.answer(text="Approved" if approved else "Denied")
+
+def add_account(update, context):
+    if context.args:
+        username = context.args[0].lstrip('@')
+        if username not in SELECT_ACCOUNTS:
+            SELECT_ACCOUNTS.append(username)
+            update.message.reply_text(
+                f"Added {username} to select accounts for visual analysis. Current: {', '.join(SELECT_ACCOUNTS)}")
+        else:
+            update.message.reply_text(f"{username} already in select accounts.")
+    else:
+        update.message.reply_text("Usage: /add @username")
+
+def remove_account(update, context):
+    if context.args:
+        username = context.args[0].lstrip('@')
+        if username in SELECT_ACCOUNTS:
+            SELECT_ACCOUNTS.remove(username)
+            update.message.reply_text(
+                f"Removed {username} from select accounts. Current: {', '.join(SELECT_ACCOUNTS)}")
+        else:
+            update.message.reply_text(f"{username} not in select accounts.")
+    else:
+        update.message.reply_text("Usage: /remove @username")
+
+def list_accounts(update, context):
+    if SELECT_ACCOUNTS:
+        update.message.reply_text(
+            f"Select accounts for visual analysis: {', '.join(SELECT_ACCOUNTS)}")
+    else:
+        update.message.reply_text("No select accounts set. Use /add @username to add.")
+
+def store_tweet(conn: sqlite3.Connection, item: dict):
+    cur = conn.cursor()
+    tweet_id = item.get("id")
+    created_at = item.get("created_at")
+    text = item.get("text", "")
+    likes = item.get("favorite_count", 0)
+    retweets = item.get("retweet_count", 0)
+    replies = item.get("reply_count", 0)
+    media = json.dumps(item.get("media", []))
+    sentiment = sentiment_analyzer(text[:512])[0]
+    vibe_score, vibe_label = compute_vibe(sentiment["label"], sentiment["score"], likes, retweets, replies)
+    cur.execute(
+        """
+        INSERT OR IGNORE INTO tweets (
+            id, username, created_at, fetch_time, text, likes, retweets,
+            replies, media, sentiment_label, sentiment_score, vibe_score,
+            vibe_label, analysis, approved, source
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            tweet_id,
+            item.get("user", {}).get("username"),
+            created_at,
+            datetime.datetime.utcnow().isoformat(),
+            text,
+            likes,
+            retweets,
+            replies,
+            media,
+            sentiment["label"],
+            float(sentiment["score"]),
+            vibe_score,
+            vibe_label,
+            None,
+            False,
+            "twitter",
+        ),
+    )
+    conn.commit()
+    return tweet_id, media
+
+def update_tweet_analysis(conn: sqlite3.Connection, tweet_id: str, analysis: dict, approved: int = None):
+    cur = conn.cursor()
+    if approved is None:
+        cur.execute("UPDATE tweets SET analysis = ? WHERE id = ?", (json.dumps(analysis), tweet_id))
+    else:
+        cur.execute("UPDATE tweets SET analysis = ?, approved = ? WHERE id = ?", (json.dumps(analysis), approved, tweet_id))
+    conn.commit()
+
 def init_db():
     conn = sqlite3.connect(DB_FILE, check_same_thread=False, timeout=30)  # Increased timeout for concurrency
     cur = conn.cursor()
     cur.execute('PRAGMA journal_mode=WAL;')  # WAL for better read/write concurrency
     cur.execute('PRAGMA synchronous = NORMAL;')  # Balance safety/performance
-    cur.execute('PRAGMA cache_size = -64000;')  # 64MB cache for faster queries
+    cur.execute('PRAGMA cache_size = -128000;')  # 128MB cache for faster queries on large data
+    cur.execute('PRAGMA busy_timeout = 60000;')  # 60s timeout for locks
     # All previous tables
     cur.execute('''
         CREATE TABLE IF NOT EXISTS tweets (
@@ -121,8 +284,128 @@ def init_db():
             source TEXT DEFAULT 'twitter'
         )
     ''')
-    cur.execute('CREATE INDEX IF NOT EXISTS idx_tweets_date ON tweets (created_at);')  # Index for time queries
-    # Similar for other tables...
+    cur.execute('CREATE INDEX IF NOT EXISTS idx_tweets_date ON tweets (created_at);')
+    cur.execute('CREATE INDEX IF NOT EXISTS idx_tweets_username ON tweets (username);')
+    cur.execute('CREATE INDEX IF NOT EXISTS idx_tweets_sentiment ON tweets (sentiment_label);')
+    # reddit_posts table
+    cur.execute('''
+        CREATE TABLE IF NOT EXISTS reddit_posts (
+            id TEXT PRIMARY KEY,
+            subreddit TEXT,
+            created_at TEXT,
+            text TEXT,
+            score INTEGER,
+            sentiment_label TEXT,
+            sentiment_score FLOAT,
+            source TEXT DEFAULT 'reddit'
+        )
+    ''')
+    cur.execute('CREATE INDEX IF NOT EXISTS idx_reddit_date ON reddit_posts (created_at);')
+    cur.execute('CREATE INDEX IF NOT EXISTS idx_reddit_subreddit ON reddit_posts (subreddit);')
+    # prices table
+    cur.execute('''
+        CREATE TABLE IF NOT EXISTS prices (
+            ticker TEXT,
+            date TEXT,
+            open REAL,
+            high REAL,
+            low REAL,
+            close REAL,
+            volume INTEGER,
+            type TEXT,
+            PRIMARY KEY (ticker, date)
+        )
+    ''')
+    cur.execute('CREATE INDEX IF NOT EXISTS idx_prices_date ON prices (date);')
+    cur.execute('CREATE INDEX IF NOT EXISTS idx_prices_ticker ON prices (ticker);')
+    # stocktwits table
+    cur.execute('''
+        CREATE TABLE IF NOT EXISTS stocktwits (
+            id TEXT PRIMARY KEY,
+            symbol TEXT,
+            created_at TEXT,
+            text TEXT,
+            sentiment TEXT,
+            source TEXT DEFAULT 'stocktwits'
+        )
+    ''')
+    cur.execute('CREATE INDEX IF NOT EXISTS idx_stocktwits_date ON stocktwits (created_at);')
+    cur.execute('CREATE INDEX IF NOT EXISTS idx_stocktwits_symbol ON stocktwits (symbol);')
+    # wallets table
+    cur.execute('''
+        CREATE TABLE IF NOT EXISTS wallets (
+            address TEXT,
+            tx_hash TEXT PRIMARY KEY,
+            timestamp TEXT,
+            value REAL,
+            from_addr TEXT,
+            to_addr TEXT,
+            source TEXT
+        )
+    ''')
+    cur.execute('CREATE INDEX IF NOT EXISTS idx_wallets_timestamp ON wallets (timestamp);')
+    cur.execute('CREATE INDEX IF NOT EXISTS idx_wallets_address ON wallets (address);')
+    # perps table
+    cur.execute('''
+        CREATE TABLE IF NOT EXISTS perps (
+            exchange TEXT,
+            symbol TEXT,
+            timestamp TEXT,
+            funding_rate REAL,
+            long_oi REAL,
+            short_oi REAL,
+            PRIMARY KEY (exchange, symbol, timestamp)
+        )
+    ''')
+    cur.execute('CREATE INDEX IF NOT EXISTS idx_perps_timestamp ON perps (timestamp);')
+    cur.execute('CREATE INDEX IF NOT EXISTS idx_perps_exchange ON perps (exchange);')
+    # order_books table
+    cur.execute('''
+        CREATE TABLE IF NOT EXISTS order_books (
+            exchange TEXT,
+            symbol TEXT,
+            timestamp TEXT,
+            bids JSON,
+            asks JSON,
+            PRIMARY KEY (exchange, symbol, timestamp)
+        )
+    ''')
+    cur.execute('CREATE INDEX IF NOT EXISTS idx_books_timestamp ON order_books (timestamp);')
+    cur.execute('CREATE INDEX IF NOT EXISTS idx_books_exchange ON order_books (exchange);')
+    # gas_prices table
+    cur.execute('''
+        CREATE TABLE IF NOT EXISTS gas_prices (
+            timestamp TEXT PRIMARY KEY,
+            fast_gas REAL,
+            average_gas REAL,
+            slow_gas REAL,
+            base_fee REAL,
+            source TEXT
+        )
+    ''')
+    cur.execute('CREATE INDEX IF NOT EXISTS idx_gas_timestamp ON gas_prices (timestamp);')
+    # patterns table
+    cur.execute('''
+        CREATE TABLE IF NOT EXISTS patterns (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            analysis_time TEXT,
+            correlations JSON,
+            granger_results JSON,
+            var_forecast JSON,
+            topics JSON,
+            anomalies JSON
+        )
+    ''')
+    # backtests table
+    cur.execute('''
+        CREATE TABLE IF NOT EXISTS backtests (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            run_time TEXT,
+            strategy TEXT,
+            results JSON
+        )
+    ''')
+    # economic_indicators table (expanded for all new sources)
     cur.execute('''
         CREATE TABLE IF NOT EXISTS economic_indicators (
             series TEXT,
@@ -133,7 +416,8 @@ def init_db():
         )
     ''')
     cur.execute('CREATE INDEX IF NOT EXISTS idx_econ_date ON economic_indicators (date);')
-    # Other tables as before
+    cur.execute('CREATE INDEX IF NOT EXISTS idx_econ_series ON economic_indicators (series);')
+    cur.execute('CREATE INDEX IF NOT EXISTS idx_econ_source ON economic_indicators (source);')
     conn.commit()
     return conn
 
@@ -273,7 +557,7 @@ def main():
     updater.start_polling()
     
     # Concurrent ingests for speed/memory
-    with ThreadPoolExecutor(max_workers=6) as executor:
+    with ThreadPoolExecutor(max_workers=4) as executor:
         futures = [
             executor.submit(ingest_free_datasets, conn),
             executor.submit(ingest_wallets, conn),
@@ -301,7 +585,7 @@ def main():
     export_for_finetuning(conn)
     backtest_strategies(conn)
     
-    scheduler = BackgroundScheduler(max_workers=10)  # More workers
+    scheduler = BackgroundScheduler(max_workers=5)
     scheduler.add_job(lambda: fetch_tweets(client, conn, bot), 'cron', hour=1, misfire_grace_time=3600)  # Grace for delays
     scheduler.add_job(lambda: ingest_wallets(conn), 'cron', hour=3)
     scheduler.add_job(lambda: ingest_perps(conn), 'cron', hour=4)


### PR DESCRIPTION
## Summary
- integrate expanded pipeline features
- add sentiment/approval helper functions
- expand SQLite schema with extra tables and indexes
- tune concurrency for modest hardware

## Testing
- `python -m py_compile extra_pipeline.py`
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_687e85db23c4832b9459a9375f4c3728