### PR TITLE
Fix tweet analysis bug and add missing import

### DIFF
--- a/main.py
+++ b/main.py
@@ -15,6 +15,7 @@ import datetime
 import sqlite3
 import logging
 import random
+import requests
 from typing import Any, Callable, List
 from dataclasses import dataclass
 
@@ -184,9 +185,9 @@ def store_tweet(conn: sqlite3.Connection, item: dict) -> TweetData:
     )
     media_json = json.dumps(tweet.media)
 
-    sentiment = sentiment_analyzer(text[:512])[0]
+    sentiment = sentiment_analyzer(tweet.text[:512])[0]
     vibe_score, vibe_label = compute_vibe(
-        sentiment["label"], sentiment["score"], likes, retweets, replies
+        sentiment["label"], sentiment["score"], tweet.likes, tweet.retweets, tweet.replies
     )
 
     cur.execute(


### PR DESCRIPTION
## Summary
- import `requests`
- use `tweet.text` and pass like/retweet/reply counts when computing vibe

## Testing
- `pytest -q`
- `python main.py` *(fails: ProxyError downloading model; no NameError)*

------
https://chatgpt.com/codex/tasks/task_e_687e90116750832bb0278be9da690f63