### PR TITLE
Support None engagement counts

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -67,3 +67,25 @@ def test_compute_vibe_labels(
 ):
     _, label = compute_vibe(sentiment_label, sentiment_score, likes, retweets, replies)
     assert label == expected_label
+
+
+@pytest.mark.parametrize(
+    "likes,retweets,replies",
+    [
+        (None, None, None),
+        (None, 5, 1),
+        (10, None, 1),
+        (10, 5, None),
+    ],
+)
+def test_compute_vibe_accepts_none(likes, retweets, replies):
+    score_none, label_none = compute_vibe("POSITIVE", 0.5, likes, retweets, replies)
+    score_zero, label_zero = compute_vibe(
+        "POSITIVE",
+        0.5,
+        0 if likes is None else likes,
+        0 if retweets is None else retweets,
+        0 if replies is None else replies,
+    )
+    assert score_none == score_zero
+    assert label_none == label_zero

--- a/utils.py
+++ b/utils.py
@@ -1,11 +1,19 @@
 """Utility functions used across pipeline scripts."""
-from typing import Tuple
+from typing import Tuple, Optional
 
 
-def compute_vibe(sentiment_label: str, sentiment_score: float,
-                 likes: int, retweets: int, replies: int) -> Tuple[float, str]:
+def compute_vibe(
+    sentiment_label: str,
+    sentiment_score: float,
+    likes: Optional[int] = None,
+    retweets: Optional[int] = None,
+    replies: Optional[int] = None,
+) -> Tuple[float, str]:
     """Compute a simplified vibe score from sentiment and engagement."""
-    engagement = (likes + retweets * 2 + replies) / 1000.0 if likes is not None else 0
+    likes = 0 if likes is None else likes
+    retweets = 0 if retweets is None else retweets
+    replies = 0 if replies is None else replies
+    engagement = (likes + retweets * 2 + replies) / 1000.0
     base_score = sentiment_score if sentiment_label == "POSITIVE" else -sentiment_score
     vibe_score = (base_score + engagement) * 5
     vibe_score = min(max(vibe_score, 0), 10)


### PR DESCRIPTION
## Summary
- allow `utils.compute_vibe` to accept `None` for like/retweet/reply counts
- test that `compute_vibe` works with `None` inputs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ea02f8a3c832bbb556869af3db854