### PR TITLE
Add docstring to config module

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,3 +1,5 @@
+"""Helper for retrieving configuration settings from environment variables."""
+
 import os
 from typing import Optional
 from pathlib import Path


### PR DESCRIPTION
## Summary
- add a short module-level docstring for configuration retrieval

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ea02fd78c832baca96ef55c57e0b1