### PR TITLE
Simplify test imports

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,49 +1,5 @@
-import sys
-import types
-import importlib
 import pytest
-
-if 'apify_client' not in sys.modules:
-    apify_client = types.ModuleType('apify_client')
-    apify_client.ApifyClient = lambda token: None
-    sys.modules['apify_client'] = apify_client
-
-if 'telegram' not in sys.modules:
-    telegram = types.ModuleType('telegram')
-    telegram.Bot = lambda token: None
-    sys.modules['telegram'] = telegram
-
-if 'apscheduler.schedulers.background' not in sys.modules:
-    background = types.ModuleType('background')
-    background.BackgroundScheduler = lambda *a, **k: None
-    schedulers = types.ModuleType('schedulers')
-    schedulers.background = background
-    apscheduler = types.ModuleType('apscheduler')
-    apscheduler.schedulers = schedulers
-    sys.modules['apscheduler'] = apscheduler
-    sys.modules['apscheduler.schedulers'] = schedulers
-    sys.modules['apscheduler.schedulers.background'] = background
-
-if 'transformers' not in sys.modules:
-    transformers = types.ModuleType('transformers')
-    transformers.pipeline = lambda *a, **k: (lambda text: [{'label': 'POSITIVE', 'score': 1.0}])
-    transformers.AutoTokenizer = types.SimpleNamespace(from_pretrained=lambda *a, **k: None)
-    transformers.AutoModelForSequenceClassification = types.SimpleNamespace(from_pretrained=lambda *a, **k: None)
-    sys.modules['transformers'] = transformers
-
-if 'requests' not in sys.modules:
-    requests = types.ModuleType('requests')
-    def _resp():
-        class R:
-            def json(self):
-                return {}
-        return R()
-    requests.get = lambda *a, **k: _resp()
-    requests.post = lambda *a, **k: _resp()
-    sys.modules['requests'] = requests
-
-main = importlib.import_module('main')
-compute_vibe = main.compute_vibe
+from utils import compute_vibe
 
 
 def test_compute_vibe_positive():


### PR DESCRIPTION
## Summary
- remove stubs and dynamic import from `tests/test_utils.py`
- keep dynamic import in `test_store_tweet` but compute vibe via `utils`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ea031c4b0832b97e4383b8618e5ec