### PR TITLE
Clean imports and add placeholders

### DIFF
--- a/advanced_pipeline.py
+++ b/advanced_pipeline.py
@@ -1,46 +1,26 @@
 import os
-import json
 import time
 import datetime
 import sqlite3
 import threading
 import random
-from apify_client import ApifyClient
-from transformers import pipeline, AutoTokenizer, AutoModelForSequenceClassification, Trainer, TrainingArguments
-from telegram import Bot, InlineKeyboardButton, InlineKeyboardMarkup
-from telegram.ext import Updater, CallbackQueryHandler, CommandHandler
 import logging
 import requests
 import pandas as pd
-import numpy as np
-from scipy.stats import pearsonr, spearmanr, kendalltau
-from statsmodels.tsa.stattools import grangercausalitytests
-from statsmodels.tsa.vector_ar.var_model import VAR
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from apify_client import ApifyClient
+from pandas_gbq import read_gbq  # For BigQuery; pip install pandas-gbq
+from telegram import Bot
+from telegram.ext import Updater, CallbackQueryHandler, CommandHandler
+from transformers import (
+    pipeline,
+    AutoTokenizer,
+    AutoModelForSequenceClassification,
+)
 from sklearn.decomposition import LatentDirichletAllocation
 from sklearn.feature_extraction.text import CountVectorizer
-from sklearn.model_selection import train_test_split, GridSearchCV
-import matplotlib.pyplot as plt
 from apscheduler.schedulers.background import BackgroundScheduler
-from backtrader import Cerebro, Strategy, indicators
-from backtrader.feeds import PandasData
-from pandas_gbq import read_gbq  # For BigQuery; pip install pandas-gbq
-import ccxt  # For order books
-import plotly.express as px  # For interactive dashboard; pip install plotly
-from catboost import CatBoostRegressor  # For ensembles; pip install catboost xgboost lightgbm
-from xgboost import XGBRegressor
-from lightgbm import LGBMRegressor
-from sklearn.ensemble import VotingRegressor
-import re  # For wallet extraction
-from concurrent.futures import ThreadPoolExecutor, as_completed  # For concurrency
-import yfinance as yf  # For Yahoo Finance; pip install yfinance
-import cryptocompare  # For CryptoCompare; pip install cryptocompare
-import openexchangerates  # For Open Exchange Rates; pip install openexchangerates, but free tier needs key
-from edgar import Company, Filing  # For SEC EDGAR; pip install python-edgar
-from noaa_sdk import NOAA  # For NOAA; pip install noaa-sdk
-from github import Github  # For GitHub; pip install PyGithub
-from imf import IMFData  # For IMF; pip install imfdatapy or similar
 from config import get_config
-from utils import compute_vibe
 
 logging.basicConfig(level=logging.DEBUG, format='%(asctime)s - %(levelname)s - %(message)s', handlers=[logging.FileHandler("system_log.txt"), logging.StreamHandler()])  # Detailed logging to file and console
 
@@ -104,6 +84,11 @@ fintwit_model = AutoModelForSequenceClassification.from_pretrained("StephanAkker
 
 # Lock for DB concurrency
 db_lock = threading.Lock()
+
+
+def compute_sentiment(text):
+    """Placeholder sentiment analysis."""
+    return "NEUTRAL", 0.5
 
 
 def init_db():
@@ -372,7 +357,135 @@ def ingest_free_datasets(conn):
         except Exception as e:
             logging.error(f"StockTwits ingest error for {symbol}: {e}")
 
-# Similar detailed, expanded functions for all ingests, with cleaning, validation, chunking, concurrency where appropriate
+# Similar detailed functions would go here
+
+
+def ingest_wallets(conn):
+    pass
+
+
+def ingest_perps(conn):
+    pass
+
+
+def ingest_order_books(conn):
+    pass
+
+
+def ingest_gas_prices(conn):
+    pass
+
+
+def ingest_alpha_vantage_economic(conn):
+    pass
+
+
+def ingest_coingecko_crypto(conn):
+    pass
+
+
+def ingest_fred_economic(conn):
+    pass
+
+
+def ingest_newsapi(conn):
+    pass
+
+
+def ingest_quandl(conn):
+    pass
+
+
+def ingest_world_bank(conn):
+    pass
+
+
+def ingest_yahoo_finance(conn):
+    pass
+
+
+def ingest_cryptocompare(conn):
+    pass
+
+
+def ingest_openexchangerates(conn):
+    pass
+
+
+def ingest_investing_scrape(conn):
+    pass
+
+
+def ingest_census_bureau(conn):
+    pass
+
+
+def ingest_openstreetmap(conn):
+    pass
+
+
+def ingest_sec_edgar(conn):
+    pass
+
+
+def ingest_noaa_climate(conn):
+    pass
+
+
+def ingest_github_repos(conn):
+    pass
+
+
+def ingest_imf(conn):
+    pass
+
+
+def fetch_tweets(client, conn, bot):
+    pass
+
+
+def analyze_patterns(conn):
+    pass
+
+
+def ensemble_prediction(conn):
+    pass
+
+
+def generate_dashboard(conn):
+    pass
+
+
+def time_series_plots(conn):
+    pass
+
+
+def export_for_finetuning(conn):
+    pass
+
+
+def backtest_strategies(conn):
+    pass
+
+
+def retry_func(func, *args, **kwargs):
+    return func(*args, **kwargs)
+
+
+def approval_handler(update, context):
+    pass
+
+
+def add_account(update, context):
+    pass
+
+
+def remove_account(update, context):
+    pass
+
+
+def list_accounts(update, context):
+    pass
 
 # main with expanded concurrency
 def main():
@@ -388,11 +501,27 @@ def main():
     updater.start_polling()
     
     ingest_functions = [
-        ingest_free_datasets, ingest_wallets, ingest_perps, ingest_order_books, ingest_gas_prices,
-        ingest_alpha_vantage_economic, ingest_coingecko_crypto, ingest_fred_economic, ingest_newsapi,
-        ingest_quandl, ingest_world_bank, ingest_yahoo_finance, ingest_cryptocompare, ingest_openexchangerates,
-        ingest_investing_scrape, ingest_census_bureau, ingest_openstreetmap, ingest_sec_edgar, ingest_noaa_climate,
-        ingest_github_repos, ingest_imf
+        ingest_free_datasets,
+        ingest_wallets,
+        ingest_perps,
+        ingest_order_books,
+        ingest_gas_prices,
+        ingest_alpha_vantage_economic,
+        ingest_coingecko_crypto,
+        ingest_fred_economic,
+        ingest_newsapi,
+        ingest_quandl,
+        ingest_world_bank,
+        ingest_yahoo_finance,
+        ingest_cryptocompare,
+        ingest_openexchangerates,
+        ingest_investing_scrape,
+        ingest_census_bureau,
+        ingest_openstreetmap,
+        ingest_sec_edgar,
+        ingest_noaa_climate,
+        ingest_github_repos,
+        ingest_imf,
     ]
     with ThreadPoolExecutor(max_workers=8) as executor:  # Increased for more ingests
         futures = [executor.submit(func, conn) for func in ingest_functions]
@@ -411,7 +540,13 @@ def main():
     backtest_strategies(conn)
     
     scheduler = BackgroundScheduler(max_workers=12, daemon=True)
-    scheduler.add_job(lambda: fetch_tweets(client, conn, bot), 'cron', hour=1, jitter=60, misfire_grace_time=7200)  # Jitter for limits, longer grace
+    scheduler.add_job(
+        lambda: fetch_tweets(client, conn, bot),
+        'cron',
+        hour=1,
+        jitter=60,
+        misfire_grace_time=7200,
+    )  # Jitter for limits
     # Add jobs for all ingests with jitter
     scheduler.start()
     

--- a/untrimmed_pipeline.py
+++ b/untrimmed_pipeline.py
@@ -4,52 +4,15 @@ import time
 import datetime
 import sqlite3
 import threading
-import random
-from apify_client import ApifyClient
-from transformers import pipeline, AutoTokenizer, AutoModelForSequenceClassification, Trainer, TrainingArguments
-from telegram import Bot, InlineKeyboardButton, InlineKeyboardMarkup
-from telegram.ext import Updater, CallbackQueryHandler, CommandHandler
 import logging
 import requests
 import pandas as pd
-import numpy as np
-from scipy.stats import pearsonr, spearmanr, kendalltau
-from statsmodels.tsa.stattools import grangercausalitytests
-from statsmodels.tsa.vector_ar.var_model import VAR
 from sklearn.decomposition import LatentDirichletAllocation
-from sklearn.feature_extraction.text import CountVectorizer
-from sklearn.model_selection import train_test_split, GridSearchCV
-import matplotlib.pyplot as plt
-from apscheduler.schedulers.background import BackgroundScheduler
-from backtrader import Cerebro, Strategy, indicators
-from backtrader.feeds import PandasData
-from pandas_gbq import read_gbq  # For BigQuery; pip install pandas-gbq
-import ccxt  # For order books
-import plotly.express as px  # For interactive dashboard; pip install plotly
-from catboost import CatBoostRegressor  # For ensembles; pip install catboost xgboost lightgbm
-from xgboost import XGBRegressor
-from lightgbm import LGBMRegressor
-from sklearn.ensemble import VotingRegressor
-import re  # For wallet extraction
-from concurrent.futures import ThreadPoolExecutor, as_completed  # For concurrency
-import yfinance as yf  # For Yahoo Finance; pip install yfinance
-import cryptocompare  # For CryptoCompare; pip install cryptocompare
-from edgar import Company, Filing  # For SEC EDGAR; pip install python-edgar
-from noaa_sdk import NOAA  # For NOAA; pip install noaa-sdk
-from github import Github  # For GitHub; pip install PyGithub
-import eodhd  # For EOD; pip install eodhd
-from twelvedata import TDClient  # For Twelve Data; pip install twelvedata
-import pydukascopy  # For Dukascopy; pip install pydukascopy
-import barchart_ondemand  # For Barchart; pip install barchart-ondemand-client-python
-from fmp_python.fmp import FMP  # For Financial Modeling Prep; pip install fmp-python
-from openexchangerates import OpenExchangeRates  # For Open Exchange Rates; pip install openexchangerates
-import moralis  # For Moralis; pip install moralis
-from covalent import CovalentClient  # For Covalent; pip install covalent-api-sdk
-import lunarcrush  # For LunarCrush; pip install lunarcrush
-import blockchair  # For Blockchair; pip install blockchair
-from glassnode.client import GlassnodeClient  # For Glassnode; pip install glassnode
+from sklearn.model_selection import GridSearchCV
+from transformers import pipeline
+from glassnode.client import GlassnodeClient
+import moralis
 from config import get_config
-from utils import compute_vibe
 
 logging.basicConfig(level=logging.DEBUG, format='%(asctime)s - %(levelname)s - %(message)s', handlers=[logging.FileHandler("system_log_detailed.txt", mode='a', encoding='utf-8'), logging.StreamHandler()])  # Detailed logging with append
 
@@ -263,6 +226,10 @@ def ingest_moralis(conn):
 # Similar ultimate advanced code for Covalent, LunarCrush, Blockchair - detailed fetching, cleaning, enrichment, etc.
 
 # main with all
+
+def main():
+    """Entry point placeholder."""
+    pass
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- prune unused imports from `advanced_pipeline` and `untrimmed_pipeline`
- stub placeholder sentiment function and ingest/analysis functions
- add minimal `main` stub for `untrimmed_pipeline`
- wrap long lists for readability

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ea0329074832bad2446e07a4b45cb