### PR TITLE
Implement timeouts for requests

### DIFF
--- a/async_pipeline.py
+++ b/async_pipeline.py
@@ -46,8 +46,14 @@ async def init_db() -> sqlite3.Connection:
 
 
 @retry(stop=stop_after_attempt(5), wait=wait_exponential(multiplier=1, max=10))
-async def fetch_json(session: ClientSession, url: str, method: str = "get", **kwargs) -> dict:
-    async with getattr(session, method)(url, **kwargs) as resp:
+async def fetch_json(
+    session: ClientSession,
+    url: str,
+    method: str = "get",
+    timeout: int = 30,
+    **kwargs,
+) -> dict:
+    async with getattr(session, method)(url, timeout=timeout, **kwargs) as resp:
         resp.raise_for_status()
         return await resp.json()
 


### PR DESCRIPTION
## Summary
- set `REQUEST_TIMEOUT` and `DUNE_MAX_POLL` constants
- apply timeout defaults in `retry_func`
- add timeout to `async_pipeline.fetch_json`
- limit the polling loop in `ingest_gas_prices`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ea14df81c832b99c8c05ff5d915b9