### PR TITLE
Add docstrings to modules and key functions

### DIFF
--- a/advanced_pipeline.py
+++ b/advanced_pipeline.py
@@ -1,3 +1,5 @@
+"""Advanced pipeline with extensive data sources and modeling."""
+
 import os
 import json
 import time

--- a/config.py
+++ b/config.py
@@ -1,3 +1,5 @@
+"""Configuration helpers for environment-based settings."""
+
 import os
 from typing import Optional
 from pathlib import Path

--- a/extra_pipeline.py
+++ b/extra_pipeline.py
@@ -1,3 +1,5 @@
+"""Expanded pipeline with advanced analytics and approval workflow."""
+
 import os
 import json
 import time
@@ -96,6 +98,7 @@ db_lock = threading.Lock()
 
 
 def compute_sentiment(text):
+    """Return sentiment label and score for given text."""
     if not text or not isinstance(text, str):
         logging.warning("Invalid text for sentiment, returning default")
         return "NEUTRAL", 0.5
@@ -107,6 +110,7 @@ def compute_sentiment(text):
         return "NEUTRAL", 0.5
 
 def analyze_visual(image_url, tweet_text):
+    """Perform basic visual analysis on an image."""
     try:
         response = requests.get(image_url, stream=True)
         if response.status_code == 200:
@@ -123,6 +127,7 @@ def analyze_visual(image_url, tweet_text):
     return analysis
 
 def send_for_approval(bot, tweet_id, tweet_text, analysis):
+    """Send tweet content and analysis to Telegram for approval."""
     try:
         markup = InlineKeyboardMarkup([
             [InlineKeyboardButton("Approve", callback_data=f"approve_{tweet_id}"),
@@ -135,6 +140,7 @@ def send_for_approval(bot, tweet_id, tweet_text, analysis):
         logging.error(f"Telegram send error: {e}")
 
 def retry_func(func, *args, **kwargs):
+    """Call *func* with retries and exponential backoff."""
     for attempt in range(MAX_RETRIES):
         try:
             return func(*args, **kwargs)

--- a/main.py
+++ b/main.py
@@ -233,6 +233,7 @@ def update_tweet_analysis(conn: sqlite3.Connection, tweet_id: str, analysis: dic
 
 
 def send_for_approval(bot: Bot, tweet_id: str, text: str, analysis: dict) -> None:
+    """Notify Telegram chat with tweet text and analysis."""
     message = f"Tweet {tweet_id}\n{text}\nAnalysis: {analysis}"
     bot.send_message(chat_id=TELEGRAM_CHAT_ID, text=message)
 

--- a/mega_pipeline.py
+++ b/mega_pipeline.py
@@ -1,3 +1,5 @@
+"""Mega pipeline exploring numerous integrations."""
+
 import os
 import json
 import time

--- a/ultimate_pipeline.py
+++ b/ultimate_pipeline.py
@@ -1,3 +1,5 @@
+"""Ultimate pipeline demonstrating full-scale processing."""
+
 import os
 import json
 import time

--- a/untrimmed_pipeline.py
+++ b/untrimmed_pipeline.py
@@ -1,3 +1,5 @@
+"""Original extended pipeline without pruning."""
+
 import os
 import json
 import time


### PR DESCRIPTION
## Summary
- add short module docstrings to pipeline and config modules
- document functions like `compute_sentiment`, `analyze_visual`, `send_for_approval` and `retry_func`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ea14e4730832bb01927c718d8ff9d