### PR TITLE
Update CI workflow with flake8 and pydocstyle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,5 +13,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          pip install flake8 pydocstyle
+      - name: Run flake8
+        run: flake8 .
+      - name: Run pydocstyle
+        run: pydocstyle .
       - name: Run tests
         run: pytest -q


### PR DESCRIPTION
## Summary
- install `flake8` and `pydocstyle` in CI
- run both linters before pytest

## Testing
- `flake8 .` *(fails: F401, E501, etc.)*
- `pydocstyle .` *(fails: D100, D103, etc.)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ea14fcfc8832b8ab38192077d558b