### PR TITLE
Optimize minute-level ingest

### DIFF
--- a/mega_pipeline.py
+++ b/mega_pipeline.py
@@ -250,11 +250,24 @@ def ingest_financial_modeling_prep(conn):
 
 def ingest_eod_historical(conn):
     eod = eodhd.EODHD(EODHD_KEY)
+    minute_enabled = "eodhd" in MINUTE_VALUABLE_SOURCES
     for ticker in EODHD_TICKERS:
         try:
-            historical = eod.get_historical_data(ticker, start=HISTORICAL_START, end=datetime.datetime.now().strftime('%Y-%m-%d'))
+            historical = eod.get_historical_data(
+                ticker,
+                start=HISTORICAL_START,
+                end=datetime.datetime.now().strftime('%Y-%m-%d'),
+            )
             fundamentals = eod.get_fundamentals(ticker)
-            intraday = fetch_with_fallback(eod.get_intraday_data, ticker=ticker, count=5000, start_date=HISTORICAL_MINUTE_START)
+            if minute_enabled:
+                intraday = fetch_with_fallback(
+                    eod.get_intraday_data,
+                    ticker=ticker,
+                    count=5000,
+                    start_date=HISTORICAL_MINUTE_START,
+                )
+            else:
+                intraday = []  # fallback to daily only
             df_hist = pd.DataFrame(historical)
             df_fund = pd.DataFrame([fundamentals]) if isinstance(fundamentals, dict) else pd.DataFrame(fundamentals)
             df_intra = pd.DataFrame(intraday)
@@ -288,9 +301,26 @@ def ingest_eod_historical(conn):
 
 def ingest_twelve_data(conn):
     td = TDClient(apikey=TWELVE_DATA_KEY)
+    minute_enabled = "twelve_data" in MINUTE_VALUABLE_SOURCES
     for symbol in TWELVE_DATA_SYMBOLS:
         try:
-            time_series = fetch_with_fallback(td.time_series, symbol=symbol, start_date=HISTORICAL_MINUTE_START, end_date=datetime.datetime.now().strftime('%Y-%m-%d'), outputsize=5000)
+            if minute_enabled:
+                time_series = fetch_with_fallback(
+                    td.time_series,
+                    symbol=symbol,
+                    start_date=HISTORICAL_MINUTE_START,
+                    end_date=datetime.datetime.now().strftime('%Y-%m-%d'),
+                    outputsize=5000,
+                )
+            else:
+                time_series = fetch_with_fallback(
+                    td.time_series,
+                    symbol=symbol,
+                    interval="1h",
+                    start_date=HISTORICAL_START,
+                    end_date=datetime.datetime.now().strftime('%Y-%m-%d'),
+                    outputsize=5000,
+                )
             time_series = time_series.as_pandas()
             fundamentals = td.fundamentals(symbol=symbol).as_pandas()
             quote = td.quote(symbol=symbol).as_dict()
@@ -323,12 +353,31 @@ def ingest_twelve_data(conn):
         time.sleep(1.5)
 
 def ingest_dukascopy(conn):
+    minute_enabled = "dukascopy" in MINUTE_VALUABLE_SOURCES
     for pair in DUKASCOPY_PAIRS:
         try:
-            try:
-                df = pydukascopy.get_historical_data(pair, from_date=HISTORICAL_MINUTE_START, to_date=datetime.datetime.now().strftime('%Y-%m-%d'), timeframe='M1')
-            except Exception:
-                df = pydukascopy.get_historical_data(pair, from_date=HISTORICAL_MINUTE_START, to_date=datetime.datetime.now().strftime('%Y-%m-%d'), timeframe='M5')
+            if minute_enabled:
+                try:
+                    df = pydukascopy.get_historical_data(
+                        pair,
+                        from_date=HISTORICAL_MINUTE_START,
+                        to_date=datetime.datetime.now().strftime('%Y-%m-%d'),
+                        timeframe='M1',
+                    )
+                except Exception:
+                    df = pydukascopy.get_historical_data(
+                        pair,
+                        from_date=HISTORICAL_MINUTE_START,
+                        to_date=datetime.datetime.now().strftime('%Y-%m-%d'),
+                        timeframe='M5',
+                    )
+            else:
+                df = pydukascopy.get_historical_data(
+                    pair,
+                    from_date=HISTORICAL_START,
+                    to_date=datetime.datetime.now().strftime('%Y-%m-%d'),
+                    timeframe='H1',
+                )
             df = df.dropna(subset=['Close', 'Volume']).sort_values('Timestamp').drop_duplicates('Timestamp')
             df['date'] = pd.to_datetime(df['Timestamp']).dt.isoformat()
             df['adjusted_close'] = df['Close']
@@ -349,13 +398,40 @@ def ingest_dukascopy(conn):
         time.sleep(3)
 
 def ingest_barchart(conn):
-    client = barchart_ondemand.BarchartOnDemandClient(api_key=BARCHART_KEY, endpoint='https://ondemand.websol.barchart.com')
+    client = barchart_ondemand.BarchartOnDemandClient(
+        api_key=BARCHART_KEY, endpoint='https://ondemand.websol.barchart.com'
+    )
+    minute_enabled = "barchart" in MINUTE_VALUABLE_SOURCES
     for symbol in BARCHART_SYMBOLS:
         try:
-            try:
-                historical = client.get_history(symbol, type='intraday', start=HISTORICAL_MINUTE_START, maxRecords=10000, order='asc', interval=1)
-            except Exception:
-                historical = client.get_history(symbol, type='intraday', start=HISTORICAL_MINUTE_START, maxRecords=10000, order='asc', interval=5)
+            if minute_enabled:
+                try:
+                    historical = client.get_history(
+                        symbol,
+                        type='intraday',
+                        start=HISTORICAL_MINUTE_START,
+                        maxRecords=10000,
+                        order='asc',
+                        interval=1,
+                    )
+                except Exception:
+                    historical = client.get_history(
+                        symbol,
+                        type='intraday',
+                        start=HISTORICAL_MINUTE_START,
+                        maxRecords=10000,
+                        order='asc',
+                        interval=5,
+                    )
+            else:
+                historical = client.get_history(
+                    symbol,
+                    type='intraday',
+                    start=HISTORICAL_START,
+                    maxRecords=10000,
+                    order='asc',
+                    interval=60,
+                )
             df = pd.DataFrame(historical['results'])
             df = df.dropna(subset=['close', 'volume']).sort_values('timestamp').drop_duplicates('timestamp')
             df['date'] = pd.to_datetime(df['timestamp']).dt.isoformat()

--- a/utils.py
+++ b/utils.py
@@ -10,9 +10,9 @@ def compute_vibe(
     replies: Optional[int] = None,
 ) -> Tuple[float, str]:
     """Compute a simplified vibe score from sentiment and engagement."""
-    likes = 0 if likes is None else likes
-    retweets = 0 if retweets is None else retweets
-    replies = 0 if replies is None else replies
+    likes = max(0, likes or 0)
+    retweets = max(0, retweets or 0)
+    replies = max(0, replies or 0)
     engagement = (likes + retweets * 2 + replies) / 1000.0
     base_score = sentiment_score if sentiment_label == "POSITIVE" else -sentiment_score
     vibe_score = (base_score + engagement) * 5


### PR DESCRIPTION
## Summary
- add checks for MINUTE_VALUABLE_SOURCES before requesting minute data
- skip minute requests when the data source is not configured
- sanitize engagement values in `compute_vibe`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ed25ed430832b825350ad174d76e4