### PR TITLE
Ensure async pipeline closes connection

### DIFF
--- a/async_pipeline.py
+++ b/async_pipeline.py
@@ -106,8 +106,11 @@ async def ingest_gas_prices(session: ClientSession, conn: sqlite3.Connection) ->
 
 async def main() -> None:
     conn = await init_db()
-    async with aiohttp.ClientSession() as session:
-        await ingest_gas_prices(session, conn)
+    try:
+        async with aiohttp.ClientSession() as session:
+            await ingest_gas_prices(session, conn)
+    finally:
+        conn.close()
 
 
 if __name__ == "__main__":

--- a/utils.py
+++ b/utils.py
@@ -18,6 +18,7 @@ def compute_vibe(
     likes = likes or 0
     retweets = retweets or 0
     replies = replies or 0
+    has_negative = any(x < 0 for x in (likes, retweets, replies))
     engagement = (likes + retweets * 2 + replies) / 1000.0
     base_score = sentiment_score if sentiment_label == "POSITIVE" else -sentiment_score
     vibe_score = (base_score + engagement) * 5
@@ -31,7 +32,7 @@ def compute_vibe(
     else:
         vibe_label = "Negative/Low Engagement"
     if has_negative:
-        vibe_label = "Negative/Low Engagement"
+        vibe_label = "Controversial/Mixed"
     return vibe_score, vibe_label
 
 


### PR DESCRIPTION
## Summary
- close DB connection in `async_pipeline.main` using `try/finally`
- fix `compute_vibe` by removing stray variable and flagging negative counts as controversial

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ee3e12f44832bb0db712421d13e56