### PR TITLE
Use sqlite context managers in entry points

### DIFF
--- a/advanced_pipeline.py
+++ b/advanced_pipeline.py
@@ -93,8 +93,9 @@ def compute_sentiment(text):
     return "NEUTRAL", 0.5
 
 
-def init_db():
-    conn = sqlite3.connect(DB_FILE, check_same_thread=False, timeout=60)  # Longer timeout
+def init_db(conn: sqlite3.Connection | None = None):
+    if conn is None:
+        conn = sqlite3.connect(DB_FILE, check_same_thread=False, timeout=60)  # Longer timeout
     cur = conn.cursor()
     cur.execute('PRAGMA journal_mode=WAL;')
     cur.execute('PRAGMA synchronous = NORMAL;')
@@ -500,9 +501,9 @@ def list_accounts(update, context):
 # main with expanded concurrency
 def main():
     """Run the minimal working portion of the advanced pipeline."""
-    conn = init_db()
-    ingest_free_datasets(conn)
-    conn.close()
+    with sqlite3.connect(DB_FILE, check_same_thread=False, timeout=60) as conn:
+        init_db(conn)
+        ingest_free_datasets(conn)
 
 if __name__ == "__main__":
     main()

--- a/ultimate_pipeline.py
+++ b/ultimate_pipeline.py
@@ -148,8 +148,9 @@ lda_gs = GridSearchCV(LatentDirichletAllocation(random_state=42, n_jobs=-1, lear
 db_lock = threading.Lock()
 
 
-def init_db():
-    conn = sqlite3.connect(DB_FILE, check_same_thread=False, timeout=180, isolation_level=None)  # Auto-commit, 3 min timeout
+def init_db(conn: sqlite3.Connection | None = None):
+    if conn is None:
+        conn = sqlite3.connect(DB_FILE, check_same_thread=False, timeout=180, isolation_level=None)  # Auto-commit, 3 min timeout
     cur = conn.cursor()
     cur.execute('PRAGMA journal_mode=WAL;')
     cur.execute('PRAGMA synchronous = NORMAL;')
@@ -338,8 +339,9 @@ def ingest_quicknode(conn):
 
 def main():
     # Placeholder main simply initializes DB
-    conn = init_db()
-    logging.info("Ultimate pipeline initialized")
+    with sqlite3.connect(DB_FILE, check_same_thread=False, timeout=180, isolation_level=None) as conn:
+        init_db(conn)
+        logging.info("Ultimate pipeline initialized")
 
 if __name__ == "__main__":
     main()

--- a/utils.py
+++ b/utils.py
@@ -18,6 +18,7 @@ def compute_vibe(
     likes = likes or 0
     retweets = retweets or 0
     replies = replies or 0
+    has_negative = any(x < 0 for x in (likes, retweets, replies))
     engagement = (likes + retweets * 2 + replies) / 1000.0
     base_score = sentiment_score if sentiment_label == "POSITIVE" else -sentiment_score
     vibe_score = (base_score + engagement) * 5
@@ -31,7 +32,7 @@ def compute_vibe(
     else:
         vibe_label = "Negative/Low Engagement"
     if has_negative:
-        vibe_label = "Negative/Low Engagement"
+        vibe_label = "Controversial/Mixed"
     return vibe_score, vibe_label
 
 


### PR DESCRIPTION
## Summary
- refactor entry point functions to open the SQLite database using `with sqlite3.connect(...) as conn:`
- allow `init_db()` helpers to accept an existing connection
- fix `compute_vibe` negative-count handling to satisfy tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ee3e00d5c832ba314d345845e2977