### PR TITLE
Add gas price ingestion test

### DIFF
--- a/tests/test_ingest_gas_prices.py
+++ b/tests/test_ingest_gas_prices.py
@@ -1,0 +1,104 @@
+import sys
+import types
+import importlib
+import sqlite3
+import datetime
+
+import pytest
+
+# Provide lightweight stubs so that the main module can be imported without
+# optional third party packages installed in the test environment.
+if 'apify_client' not in sys.modules:
+    apify_client = types.ModuleType('apify_client')
+    apify_client.ApifyClient = lambda token: None
+    sys.modules['apify_client'] = apify_client
+
+if 'telegram' not in sys.modules:
+    telegram = types.ModuleType('telegram')
+    telegram.Bot = lambda token: None
+    sys.modules['telegram'] = telegram
+
+if 'apscheduler.schedulers.background' not in sys.modules:
+    background = types.ModuleType('background')
+    background.BackgroundScheduler = lambda *a, **k: None
+    schedulers = types.ModuleType('schedulers')
+    schedulers.background = background
+    apscheduler = types.ModuleType('apscheduler')
+    apscheduler.schedulers = schedulers
+    sys.modules['apscheduler'] = apscheduler
+    sys.modules['apscheduler.schedulers'] = schedulers
+    sys.modules['apscheduler.schedulers.background'] = background
+
+if 'transformers' not in sys.modules:
+    transformers = types.ModuleType('transformers')
+    transformers.pipeline = lambda *a, **k: (lambda text: [{'label': 'POSITIVE', 'score': 1.0}])
+    transformers.AutoTokenizer = types.SimpleNamespace(from_pretrained=lambda *a, **k: None)
+    transformers.AutoModelForSequenceClassification = types.SimpleNamespace(from_pretrained=lambda *a, **k: None)
+    sys.modules['transformers'] = transformers
+
+if 'requests' not in sys.modules:
+    requests = types.ModuleType('requests')
+    def _resp():
+        class R:
+            def json(self):
+                return {}
+        return R()
+    requests.get = lambda *a, **k: _resp()
+    requests.post = lambda *a, **k: _resp()
+    sys.modules['requests'] = requests
+
+main = importlib.import_module('main')
+
+
+def setup_in_memory_db(monkeypatch: pytest.MonkeyPatch) -> sqlite3.Connection:
+    monkeypatch.setattr(main, 'DB_FILE', ':memory:')
+    return main.init_db()
+
+
+def test_ingest_gas_prices_inserts(monkeypatch: pytest.MonkeyPatch):
+    conn = setup_in_memory_db(monkeypatch)
+
+    monkeypatch.setattr(main, 'DUNE_MAX_POLL', 1)
+    monkeypatch.setattr(main.time, 'sleep', lambda s: None)
+    monkeypatch.setattr(main, 'retry_func', lambda func, *a, **kw: func(*a, **kw))
+
+    def dummy_get(url, *a, **kw):
+        if 'gaschart' in url:
+            return types.SimpleNamespace(json=lambda: {'result': [{'unixTimeStamp': '1', 'gasPrice': '42'}]})
+        if 'gasoracle' in url:
+            return types.SimpleNamespace(json=lambda: {'result': {'FastGasPrice': '10', 'ProposeGasPrice': '12', 'SafeGasPrice': '8', 'LastBlock': '123'}})
+        if 'status' in url:
+            return types.SimpleNamespace(json=lambda: {'state': 'QUERY_STATE_COMPLETED'})
+        if 'results' in url:
+            return types.SimpleNamespace(json=lambda: {'rows': [{'day': '2023-01-01', 'avg_gas_gwei': 30}]})
+        raise AssertionError(f'Unexpected GET {url}')
+
+    def dummy_post(url, *a, **kw):
+        if 'execute' in url:
+            return types.SimpleNamespace(json=lambda: {'execution_id': 'xyz'})
+        raise AssertionError(f'Unexpected POST {url}')
+
+    monkeypatch.setattr(main.requests, 'get', dummy_get)
+    monkeypatch.setattr(main.requests, 'post', dummy_post)
+
+    main.ingest_gas_prices(conn)
+
+    cur = conn.cursor()
+    rows = cur.execute(
+        'SELECT timestamp, fast_gas, average_gas, slow_gas, base_fee, source FROM gas_prices'
+    ).fetchall()
+
+    assert len(rows) == 3
+    data = {row[5]: row for row in rows}
+
+    hist = data['etherscan_historical']
+    assert hist[2] == 42.0
+
+    current = data['etherscan_current']
+    assert current[1] == 10.0
+    assert current[2] == 12.0
+    assert current[3] == 8.0
+    assert current[4] == 123.0
+
+    dune = data['dune']
+    assert dune[2] == 30

--- a/utils.py
+++ b/utils.py
@@ -15,9 +15,12 @@ def compute_vibe(
     # Normalize engagement counts so that missing or negative values don't
     # artificially lower the vibe score.
     # Preserve negative counts to penalize posts receiving backlash or bot spam
-    likes = likes or 0
-    retweets = retweets or 0
-    replies = replies or 0
+    has_negative = any(
+        x is not None and x < 0 for x in (likes, retweets, replies)
+    )
+    likes = max(likes or 0, 0)
+    retweets = max(retweets or 0, 0)
+    replies = max(replies or 0, 0)
     engagement = (likes + retweets * 2 + replies) / 1000.0
     base_score = sentiment_score if sentiment_label == "POSITIVE" else -sentiment_score
     vibe_score = (base_score + engagement) * 5
@@ -31,7 +34,7 @@ def compute_vibe(
     else:
         vibe_label = "Negative/Low Engagement"
     if has_negative:
-        vibe_label = "Negative/Low Engagement"
+        vibe_label = "Controversial/Mixed"
     return vibe_score, vibe_label
 
 


### PR DESCRIPTION
## Summary
- add test for ingest_gas_prices using mocked HTTP calls
- fix compute_vibe helper to handle negative engagement values

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ee3e09c1c832bb86e51bcd1df611e