### PR TITLE
Refactor tests to use fixtures for stubs

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,69 @@
+import sys
+import types
+import importlib
+import pytest
+
+
+@pytest.fixture(scope="session", autouse=True)
+def stub_optional_dependencies():
+    """Insert lightweight stubs for optional third party packages."""
+    # apify_client
+    if 'apify_client' not in sys.modules:
+        apify_client = types.ModuleType('apify_client')
+        apify_client.ApifyClient = lambda token: None
+        sys.modules['apify_client'] = apify_client
+
+    # telegram
+    if 'telegram' not in sys.modules:
+        telegram = types.ModuleType('telegram')
+        telegram.Bot = lambda token: None
+        sys.modules['telegram'] = telegram
+
+    # apscheduler background scheduler
+    if 'apscheduler.schedulers.background' not in sys.modules:
+        background = types.ModuleType('background')
+        background.BackgroundScheduler = lambda *a, **k: None
+        schedulers = types.ModuleType('schedulers')
+        schedulers.background = background
+        apscheduler = types.ModuleType('apscheduler')
+        apscheduler.schedulers = schedulers
+        sys.modules['apscheduler'] = apscheduler
+        sys.modules['apscheduler.schedulers'] = schedulers
+        sys.modules['apscheduler.schedulers.background'] = background
+
+    # transformers sentiment pipeline
+    if 'transformers' not in sys.modules:
+        transformers = types.ModuleType('transformers')
+        transformers.pipeline = lambda *a, **k: (lambda text: [{'label': 'POSITIVE', 'score': 1.0}])
+        transformers.AutoTokenizer = types.SimpleNamespace(from_pretrained=lambda *a, **k: None)
+        transformers.AutoModelForSequenceClassification = types.SimpleNamespace(from_pretrained=lambda *a, **k: None)
+        sys.modules['transformers'] = transformers
+
+    # requests
+    if 'requests' not in sys.modules:
+        requests = types.ModuleType('requests')
+
+        def _resp():
+            class R:
+                def json(self):
+                    return {}
+            return R()
+
+        requests.get = lambda *a, **k: _resp()
+        requests.post = lambda *a, **k: _resp()
+        sys.modules['requests'] = requests
+
+    # If utils was imported before stubbing requests, ensure it uses the stub
+    if 'utils' in sys.modules:
+        utils = sys.modules['utils']
+        utils.requests = sys.modules['requests']
+
+    yield
+
+
+@pytest.fixture
+def main_module(stub_optional_dependencies):
+    """Import the main module after stubs are in place."""
+    if 'main' in sys.modules:
+        return importlib.reload(sys.modules['main'])
+    return importlib.import_module('main')

--- a/tests/test_ingest_gas_prices.py
+++ b/tests/test_ingest_gas_prices.py
@@ -1,66 +1,19 @@
-import sys
 import types
-import importlib
 import sqlite3
-import datetime
-
 import pytest
 
-# Provide lightweight stubs so that the main module can be imported without
-# optional third party packages installed in the test environment.
-if 'apify_client' not in sys.modules:
-    apify_client = types.ModuleType('apify_client')
-    apify_client.ApifyClient = lambda token: None
-    sys.modules['apify_client'] = apify_client
 
-if 'telegram' not in sys.modules:
-    telegram = types.ModuleType('telegram')
-    telegram.Bot = lambda token: None
-    sys.modules['telegram'] = telegram
-
-if 'apscheduler.schedulers.background' not in sys.modules:
-    background = types.ModuleType('background')
-    background.BackgroundScheduler = lambda *a, **k: None
-    schedulers = types.ModuleType('schedulers')
-    schedulers.background = background
-    apscheduler = types.ModuleType('apscheduler')
-    apscheduler.schedulers = schedulers
-    sys.modules['apscheduler'] = apscheduler
-    sys.modules['apscheduler.schedulers'] = schedulers
-    sys.modules['apscheduler.schedulers.background'] = background
-
-if 'transformers' not in sys.modules:
-    transformers = types.ModuleType('transformers')
-    transformers.pipeline = lambda *a, **k: (lambda text: [{'label': 'POSITIVE', 'score': 1.0}])
-    transformers.AutoTokenizer = types.SimpleNamespace(from_pretrained=lambda *a, **k: None)
-    transformers.AutoModelForSequenceClassification = types.SimpleNamespace(from_pretrained=lambda *a, **k: None)
-    sys.modules['transformers'] = transformers
-
-if 'requests' not in sys.modules:
-    requests = types.ModuleType('requests')
-    def _resp():
-        class R:
-            def json(self):
-                return {}
-        return R()
-    requests.get = lambda *a, **k: _resp()
-    requests.post = lambda *a, **k: _resp()
-    sys.modules['requests'] = requests
-
-main = importlib.import_module('main')
-
-
-def setup_in_memory_db(monkeypatch: pytest.MonkeyPatch) -> sqlite3.Connection:
+def setup_in_memory_db(monkeypatch: pytest.MonkeyPatch, main):
     monkeypatch.setattr(main, 'DB_FILE', ':memory:')
     return main.init_db()
 
 
-def test_ingest_gas_prices_inserts(monkeypatch: pytest.MonkeyPatch):
-    conn = setup_in_memory_db(monkeypatch)
+def test_ingest_gas_prices_inserts(monkeypatch: pytest.MonkeyPatch, main_module):
+    conn = setup_in_memory_db(monkeypatch, main_module)
 
-    monkeypatch.setattr(main, 'DUNE_MAX_POLL', 1)
-    monkeypatch.setattr(main.time, 'sleep', lambda s: None)
-    monkeypatch.setattr(main, 'retry_func', lambda func, *a, **kw: func(*a, **kw))
+    monkeypatch.setattr(main_module, 'DUNE_MAX_POLL', 1)
+    monkeypatch.setattr(main_module.time, 'sleep', lambda s: None)
+    monkeypatch.setattr(main_module, 'retry_func', lambda func, *a, **kw: func(*a, **kw))
 
     def dummy_get(url, *a, **kw):
         if 'gaschart' in url:
@@ -78,10 +31,10 @@ def test_ingest_gas_prices_inserts(monkeypatch: pytest.MonkeyPatch):
             return types.SimpleNamespace(json=lambda: {'execution_id': 'xyz'})
         raise AssertionError(f'Unexpected POST {url}')
 
-    monkeypatch.setattr(main.requests, 'get', dummy_get)
-    monkeypatch.setattr(main.requests, 'post', dummy_post)
+    monkeypatch.setattr(main_module.requests, 'get', dummy_get)
+    monkeypatch.setattr(main_module.requests, 'post', dummy_post)
 
-    main.ingest_gas_prices(conn)
+    main_module.ingest_gas_prices(conn)
 
     cur = conn.cursor()
     rows = cur.execute(
@@ -102,3 +55,4 @@ def test_ingest_gas_prices_inserts(monkeypatch: pytest.MonkeyPatch):
 
     dune = data['dune']
     assert dune[2] == 30
+

--- a/tests/test_store_tweet.py
+++ b/tests/test_store_tweet.py
@@ -1,61 +1,15 @@
-import sys
-import types
-import importlib
 import pytest
 from utils import compute_vibe
 
-# Provide lightweight stubs so that the main module can be imported without
-# optional third party packages installed in the test environment.
-if 'apify_client' not in sys.modules:
-    apify_client = types.ModuleType('apify_client')
-    apify_client.ApifyClient = lambda token: None
-    sys.modules['apify_client'] = apify_client
 
-if 'telegram' not in sys.modules:
-    telegram = types.ModuleType('telegram')
-    telegram.Bot = lambda token: None
-    sys.modules['telegram'] = telegram
-
-if 'apscheduler.schedulers.background' not in sys.modules:
-    background = types.ModuleType('background')
-    background.BackgroundScheduler = lambda *a, **k: None
-    schedulers = types.ModuleType('schedulers')
-    schedulers.background = background
-    apscheduler = types.ModuleType('apscheduler')
-    apscheduler.schedulers = schedulers
-    sys.modules['apscheduler'] = apscheduler
-    sys.modules['apscheduler.schedulers'] = schedulers
-    sys.modules['apscheduler.schedulers.background'] = background
-
-if 'transformers' not in sys.modules:
-    transformers = types.ModuleType('transformers')
-    transformers.pipeline = lambda *a, **k: (lambda text: [{'label': 'POSITIVE', 'score': 1.0}])
-    transformers.AutoTokenizer = types.SimpleNamespace(from_pretrained=lambda *a, **k: None)
-    transformers.AutoModelForSequenceClassification = types.SimpleNamespace(from_pretrained=lambda *a, **k: None)
-    sys.modules['transformers'] = transformers
-
-if 'requests' not in sys.modules:
-    requests = types.ModuleType('requests')
-    def _resp():
-        class R:
-            def json(self):
-                return {}
-        return R()
-    requests.get = lambda *a, **k: _resp()
-    requests.post = lambda *a, **k: _resp()
-    sys.modules['requests'] = requests
-
-main = importlib.import_module('main')
-
-
-def setup_in_memory_db(monkeypatch):
+def setup_in_memory_db(monkeypatch, main):
     monkeypatch.setattr(main, "DB_FILE", ":memory:")
     return main.init_db()
 
 
-def test_store_tweet_inserts(monkeypatch):
-    conn = setup_in_memory_db(monkeypatch)
-    monkeypatch.setattr(main, "sentiment_analyzer", lambda text: [{"label": "POSITIVE", "score": 0.5}])
+def test_store_tweet_inserts(monkeypatch, main_module):
+    conn = setup_in_memory_db(monkeypatch, main_module)
+    monkeypatch.setattr(main_module, "sentiment_analyzer", lambda text: [{"label": "POSITIVE", "score": 0.5}])
     item = {
         "id": "123",
         "user": {"username": "alice"},
@@ -64,14 +18,14 @@ def test_store_tweet_inserts(monkeypatch):
         "favorite_count": 10,
         "retweet_count": 2,
         "reply_count": 1,
-        "media": ["img1"]
+        "media": ["img1"],
     }
-    tweet = main.store_tweet(conn, item)
+    tweet = main_module.store_tweet(conn, item)
 
     cur = conn.cursor()
     row = cur.execute(
         "SELECT id, username, text, sentiment_label, sentiment_score, vibe_score, vibe_label FROM tweets WHERE id=?",
-        ("123",)
+        ("123",),
     ).fetchone()
 
     assert row is not None
@@ -85,5 +39,4 @@ def test_store_tweet_inserts(monkeypatch):
     assert row[6] == expected_label
 
     assert tweet.text == item["text"]
-
 


### PR DESCRIPTION
## Summary
- introduce `tests/conftest.py` providing lightweight stubs for optional deps
- refactor `test_ingest_gas_prices` and `test_store_tweet` to use new fixtures

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f07d01e7c832b92d28f1c5f0ecf80