### PR TITLE
Improve Dune request error handling

### DIFF
--- a/tests/test_dune.py
+++ b/tests/test_dune.py
@@ -1,0 +1,23 @@
+import types
+import pytest
+
+
+def test_execute_dune_query_http_error(monkeypatch, dune_module):
+    class DummyHTTPError(Exception):
+        def __init__(self, status):
+            self.response = types.SimpleNamespace(status_code=status)
+
+    class Response:
+        def __init__(self, status):
+            self.status_code = status
+        def json(self):
+            return {}
+        def raise_for_status(self):
+            if self.status_code >= 400:
+                raise DummyHTTPError(self.status_code)
+
+    monkeypatch.setattr(dune_module.requests, "post", lambda *a, **k: Response(400))
+    monkeypatch.setattr(dune_module.requests, "get", lambda *a, **k: Response(200))
+
+    with pytest.raises(DummyHTTPError):
+        dune_module.execute_dune_query("123", "key")

--- a/tests/test_ingest_gas_prices.py
+++ b/tests/test_ingest_gas_prices.py
@@ -17,18 +17,18 @@ def test_ingest_gas_prices_inserts(monkeypatch: pytest.MonkeyPatch, gas_module, 
 
     def dummy_get(url, *a, **kw):
         if 'gaschart' in url:
-            return types.SimpleNamespace(json=lambda: {'result': [{'unixTimeStamp': '1', 'gasPrice': '42'}]})
+            return types.SimpleNamespace(json=lambda: {'result': [{'unixTimeStamp': '1', 'gasPrice': '42'}]}, raise_for_status=lambda: None)
         if 'gasoracle' in url:
-            return types.SimpleNamespace(json=lambda: {'result': {'FastGasPrice': '10', 'ProposeGasPrice': '12', 'SafeGasPrice': '8', 'LastBlock': '123'}})
+            return types.SimpleNamespace(json=lambda: {'result': {'FastGasPrice': '10', 'ProposeGasPrice': '12', 'SafeGasPrice': '8', 'LastBlock': '123'}}, raise_for_status=lambda: None)
         if 'status' in url:
-            return types.SimpleNamespace(json=lambda: {'state': 'QUERY_STATE_COMPLETED'})
+            return types.SimpleNamespace(json=lambda: {'state': 'QUERY_STATE_COMPLETED'}, raise_for_status=lambda: None)
         if 'results' in url:
-            return types.SimpleNamespace(json=lambda: {'rows': [{'day': '2023-01-01', 'avg_gas_gwei': 30}]})
+            return types.SimpleNamespace(json=lambda: {'rows': [{'day': '2023-01-01', 'avg_gas_gwei': 30}]}, raise_for_status=lambda: None)
         raise AssertionError(f'Unexpected GET {url}')
 
     def dummy_post(url, *a, **kw):
         if 'execute' in url:
-            return types.SimpleNamespace(json=lambda: {'execution_id': 'xyz'})
+            return types.SimpleNamespace(json=lambda: {'execution_id': 'xyz'}, raise_for_status=lambda: None)
         raise AssertionError(f'Unexpected POST {url}')
 
     monkeypatch.setattr(gas_module.requests, 'get', dummy_get)


### PR DESCRIPTION
## Summary
- enforce HTTP status checks in Dune API helper
- log status codes and raise exceptions when Dune requests fail
- update gas price ingestion test helpers to include `raise_for_status`
- add regression test for HTTP 400 responses

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f157e2828832ba59aa3358ef1c059