### PR TITLE
Preserve exception in retry logic

### DIFF
--- a/pipelines/gas.py
+++ b/pipelines/gas.py
@@ -37,13 +37,19 @@ def retry_func(func: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
         requests.options,
     }:
         kwargs.setdefault("timeout", REQUEST_TIMEOUT)
+    last_exc: Exception | None = None
     for attempt in range(retries):
         try:
             return func(*args, **kwargs)
         except Exception as exc:  # pragma: no cover - best effort logging
+            last_exc = exc
             wait = base_backoff * (2 ** attempt) + random.random()
-            logging.warning("Retry %s/%s after error: %s", attempt + 1, retries, exc)
+            logging.warning(
+                "Retry %s/%s after error: %s", attempt + 1, retries, exc
+            )
             time.sleep(wait)
+    if last_exc is not None:
+        raise last_exc
     raise RuntimeError(f"Failed after {retries} retries")
 
 

--- a/tests/test_retry_func.py
+++ b/tests/test_retry_func.py
@@ -1,0 +1,24 @@
+import pytest
+
+class DummyError(Exception):
+    pass
+
+
+def test_retry_func_preserves_exception(monkeypatch, gas_module):
+    calls = []
+
+    def always_fail():
+        calls.append(1)
+        raise DummyError("boom")
+
+    monkeypatch.setattr(gas_module.time, "sleep", lambda s: None)
+    # ensure all HTTP methods exist on the requests stub
+    for method in ["put", "delete", "patch", "head", "options"]:
+        monkeypatch.setattr(
+            gas_module.requests, method, lambda *a, **k: None, raising=False
+        )
+
+    with pytest.raises(DummyError):
+        gas_module.retry_func(always_fail, retries=3, base_backoff=0)
+
+    assert len(calls) == 3


### PR DESCRIPTION
## Summary
- keep the last exception in `retry_func`
- re-raise it when retries are exhausted
- add regression test for `retry_func` preserving error type

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f1581478c832b9bdf152783dc4c3e