### PR TITLE
Add dataset retry iteration helper

### DIFF
--- a/pipelines/tweets.py
+++ b/pipelines/tweets.py
@@ -21,6 +21,24 @@ from utils import compute_vibe
 
 from .gas import retry_func
 
+
+def iterate_with_retry(client: ApifyClient, dataset_id: str):
+    """Yield dataset items, retrying on transient errors."""
+    offset = 0
+    while True:
+        iterator = retry_func(client.dataset(dataset_id).iterate_items, offset=offset)
+        got_any = False
+        try:
+            for item in iterator:
+                got_any = True
+                offset += 1
+                yield item
+        except Exception as exc:  # pragma: no cover - best effort logging
+            logging.warning("Dataset iteration failed: %s", exc)
+            continue
+        if not got_any:
+            break
+
 USERNAMES = ["onchainlens", "unipcs", "stalkchain", "elonmusk", "example2"]
 MAX_TWEETS_PER_USER = 1000
 HISTORICAL_START = "2017-01-01"
@@ -143,7 +161,7 @@ def fetch_tweets(client: ApifyClient, conn: sqlite3.Connection, bot: Bot) -> Non
     except Exception as exc:  # pragma: no cover - best effort logging
         logging.error("Error parsing Apify run result: %s", exc)
         return
-    for item in retry_func(client.dataset(dataset_id).iterate_items):
+    for item in iterate_with_retry(client, dataset_id):
         try:
             store_tweet(conn, item)
         except Exception as exc:  # pragma: no cover - best effort logging

--- a/tests/test_iterate_with_retry.py
+++ b/tests/test_iterate_with_retry.py
@@ -1,0 +1,28 @@
+def test_iterate_with_retry_recovers(monkeypatch, tweets_module):
+    items = [{'id': 0}, {'id': 1}, {'id': 2}]
+
+    class DummyDataset:
+        def __init__(self):
+            self.calls = 0
+        def iterate_items(self, offset=0):
+            self.calls += 1
+            for idx in range(offset, len(items)):
+                if self.calls == 1 and idx == 1:
+                    raise RuntimeError('fail')
+                yield items[idx]
+
+    class DummyClient:
+        def __init__(self, dataset):
+            self._dataset = dataset
+        def dataset(self, dataset_id):
+            assert dataset_id == 'ds1'
+            return self._dataset
+
+    dummy = DummyDataset()
+    client = DummyClient(dummy)
+    monkeypatch.setattr(tweets_module, 'retry_func', lambda func, *a, **kw: func(*a, **kw))
+
+    result = list(tweets_module.iterate_with_retry(client, 'ds1'))
+
+    assert result == items
+    assert dummy.calls >= 2


### PR DESCRIPTION
## Summary
- add `iterate_with_retry` helper to retry dataset iteration
- use the new helper when fetching tweets
- test dataset iteration retry logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f16c9d748832b9d5f9a7a2fe7c313