### PR TITLE
Add config placeholder validation

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,6 +1,7 @@
 """Helper for retrieving configuration settings from environment variables."""
 
 import os
+import warnings
 from typing import Optional
 from pathlib import Path
 
@@ -14,9 +15,37 @@ if load_dotenv and ENV_PATH.exists():
     load_dotenv(str(ENV_PATH))
 
 
+PLACEHOLDERS = [
+    "xxxxxxxxxx",
+    "your-project-id",
+    "your-quicknode-endpoint",
+]
+
+
+def _is_placeholder(value: str) -> bool:
+    """Return True if the value looks like a placeholder."""
+    if value is None:
+        return False
+    lowered = value.lower()
+    if "x" * 6 in lowered and lowered.strip("x") == "":
+        return True
+    for ph in PLACEHOLDERS:
+        if ph in lowered:
+            return True
+    return False
+
+
 def get_config(name: str, default: Optional[str] = None) -> str:
     """Retrieve configuration from environment variables."""
-    value = os.getenv(name, default)
+    env_value = os.getenv(name)
+    value = env_value if env_value is not None else default
     if value is None:
         raise RuntimeError(f"Missing configuration for {name}")
+
+    if env_value is None and _is_placeholder(value):
+        warnings.warn(
+            f"Configuration {name} is using a placeholder value: {value}",
+            RuntimeWarning,
+        )
+
     return value

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,12 @@
+import pytest
+import importlib
+
+import config
+
+
+def test_get_config_warns_for_placeholder(monkeypatch):
+    monkeypatch.delenv("PLACEHOLDER_KEY", raising=False)
+    with pytest.warns(RuntimeWarning):
+        value = config.get_config("PLACEHOLDER_KEY", "xxxxxxxxxx")
+    assert value == "xxxxxxxxxx"
+


### PR DESCRIPTION
## Summary
- warn when config values match common placeholders
- add regression test for placeholder detection

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f16cad9c4832babfc384b75e50e43