### PR TITLE
Add retry tests and iterate_with_retry helper

### DIFF
--- a/tests/test_fetch_tweets.py
+++ b/tests/test_fetch_tweets.py
@@ -1,0 +1,56 @@
+import types
+import pytest
+
+
+def setup_in_memory_db(monkeypatch, db_module):
+    monkeypatch.setattr(db_module, "DB_FILE", ":memory:")
+    return db_module.init_db()
+
+
+class FailingDataset:
+    def __init__(self, items):
+        self.items = items
+        self.calls = 0
+
+    def iterate_items(self):
+        self.calls += 1
+        if self.calls == 1:
+            def gen():
+                raise RuntimeError("boom")
+                yield  # pragma: no cover - never reached
+            return gen()
+        return iter(self.items)
+
+
+class DummyClient:
+    def __init__(self, dataset):
+        self.dataset_obj = dataset
+
+    def actor(self, actor_id):
+        return types.SimpleNamespace(call=lambda run_input: {"defaultDatasetId": "d1"})
+
+    def dataset(self, dataset_id):
+        return self.dataset_obj
+
+    def user(self):
+        return types.SimpleNamespace(get=lambda: {})
+
+
+def test_iterate_with_retry(monkeypatch, tweets_module, db_module):
+    conn = setup_in_memory_db(monkeypatch, db_module)
+    items = [{"id": "1", "user": {"username": "alice"}, "created_at": "2023", "text": "hi"}]
+    dataset = FailingDataset(items)
+    client = DummyClient(dataset)
+
+    monkeypatch.setattr(tweets_module, "sentiment_analyzer", lambda text: [{"label": "POSITIVE", "score": 0.5}])
+    monkeypatch.setattr(tweets_module, "monitor_costs", lambda c: None)
+    monkeypatch.setattr(tweets_module, "retry_func", lambda func, *a, **kw: func(*a, **kw))
+    monkeypatch.setattr(tweets_module.time, "sleep", lambda s: None)
+    monkeypatch.setattr(tweets_module, "MAX_TWEETS_PER_USER", 1)
+    monkeypatch.setattr(tweets_module, "USERNAMES", ["alice"])
+
+    tweets_module.fetch_tweets(client, conn, None)
+
+    rows = conn.cursor().execute("SELECT id FROM tweets").fetchall()
+    assert len(rows) == 1
+    assert dataset.calls == 2

--- a/tests/test_ingest_gas_prices.py
+++ b/tests/test_ingest_gas_prices.py
@@ -58,3 +58,64 @@ def test_ingest_gas_prices_inserts(monkeypatch: pytest.MonkeyPatch, gas_module, 
     dune = data['dune']
     assert dune[2] == 30
 
+
+def test_ingest_gas_prices_http_error(monkeypatch: pytest.MonkeyPatch, gas_module, dune_module, db_module):
+    conn = setup_in_memory_db(monkeypatch, db_module)
+
+    monkeypatch.setattr(gas_module.time, 'sleep', lambda s: None)
+    monkeypatch.setattr(gas_module, 'retry_func', lambda func, *a, **kw: func(*a, **kw))
+
+    class DummyHTTPError(Exception):
+        pass
+
+    def dummy_get(url, *a, **kw):
+        raise DummyHTTPError('server error')
+
+    monkeypatch.setattr(gas_module.requests, 'get', dummy_get)
+    monkeypatch.setattr(dune_module.requests, 'get', dummy_get)
+
+    with pytest.raises(DummyHTTPError):
+        gas_module.ingest_gas_prices(conn)
+
+    cur = conn.cursor()
+    rows = cur.execute('SELECT * FROM gas_prices').fetchall()
+    assert rows == []
+
+
+def test_ingest_gas_prices_bad_json(monkeypatch: pytest.MonkeyPatch, gas_module, dune_module, db_module):
+    conn = setup_in_memory_db(monkeypatch, db_module)
+
+    monkeypatch.setattr(gas_module, 'DUNE_MAX_POLL', 1)
+    monkeypatch.setattr(gas_module.time, 'sleep', lambda s: None)
+    monkeypatch.setattr(gas_module, 'retry_func', lambda func, *a, **kw: func(*a, **kw))
+
+    def invalid_json():
+        raise ValueError('bad json')
+
+    def dummy_get(url, *a, **kw):
+        if 'gaschart' in url:
+            return types.SimpleNamespace(json=invalid_json)
+        if 'gasoracle' in url:
+            return types.SimpleNamespace(json=lambda: {'result': {'FastGasPrice': '10', 'ProposeGasPrice': '12', 'SafeGasPrice': '8', 'LastBlock': '123'}})
+        if 'status' in url:
+            return types.SimpleNamespace(json=lambda: {'state': 'QUERY_STATE_COMPLETED'})
+        if 'results' in url:
+            return types.SimpleNamespace(json=lambda: {'rows': [{'day': '2023-01-01', 'avg_gas_gwei': 30}]})
+        raise AssertionError(f'Unexpected GET {url}')
+
+    def dummy_post(url, *a, **kw):
+        if 'execute' in url:
+            return types.SimpleNamespace(json=lambda: {'execution_id': 'xyz'})
+        raise AssertionError(f'Unexpected POST {url}')
+
+    monkeypatch.setattr(gas_module.requests, 'get', dummy_get)
+    monkeypatch.setattr(gas_module.requests, 'post', dummy_post)
+    monkeypatch.setattr(dune_module.requests, 'get', dummy_get)
+    monkeypatch.setattr(dune_module.requests, 'post', dummy_post)
+
+    gas_module.ingest_gas_prices(conn)
+
+    rows = conn.cursor().execute('SELECT source FROM gas_prices').fetchall()
+    # one row each from etherscan_current and dune
+    assert sorted(r[0] for r in rows) == ['dune', 'etherscan_current']
+


### PR DESCRIPTION
## Summary
- extend gas price ingestion tests for HTTP errors and bad JSON
- add iterate_with_retry helper for Apify dataset iteration
- update fetch_tweets to use iterate_with_retry
- add tests for Apify iteration retry logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f16cd0cf8832baceaedc15cad1c44