### PR TITLE
Add Docker container support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+CMD ["python", "async_pipeline.py"]

--- a/README.md
+++ b/README.md
@@ -80,6 +80,15 @@ root:
 pytest -q
 ```
 
+## Docker
+
+Build a container image that runs the async pipeline:
+
+```bash
+docker build -t grok721 .
+docker run --rm --env-file .env grok721
+```
+
 ## License
 
 This project is licensed under the [MIT License](LICENSE).


### PR DESCRIPTION
## Summary
- add Dockerfile running `async_pipeline.py`
- document build and run commands in README

## Testing
- `pytest -q` *(fails: iterate_with_retry takes 1 positional argument but 2 given)*

------
https://chatgpt.com/codex/tasks/task_e_687fa1e729ec832baddb6679801589bf