### PR TITLE
Update README with virtualenv setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,17 @@ the pipelines can be found in [docs/dune_dashboards.md](docs/dune_dashboards.md)
 
 ## Dependencies
 
+Create and activate a local virtual environment before installing
+the requirements:
+
+```bash
+python3 -m venv venv
+source venv/bin/activate
+```
+
+Using a virtual environment helps keep dependencies isolated on macOS and
+prevents conflicts with system packages.
+
 The `requirements.txt` file now contains only the minimal packages needed to
 run `main.py` and `async_pipeline.py`.
 Install these core dependencies first:


### PR DESCRIPTION
## Summary
- add steps to create and activate a Python virtual environment
- mention that using a venv keeps dependencies isolated on macOS

## Testing
- `pytest -q` *(fails: iterate_with_retry() takes 1 positional argument but 2 were given)*

------
https://chatgpt.com/codex/tasks/task_e_687fa1e52cd0832ba52a111b856acafa