### PR TITLE
Make tweets limit configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,3 +41,4 @@ QUICKNODE_RPC=https://your-quicknode-endpoint
 QUANDL_KEY=xxxxxxxxxx
 DB_FILE=super_db.db
 ACTOR_ID=kaitoeasyapi/twitter-x-data-tweet-scraper-pay-per-result-cheapest
+MAX_TWEETS_PER_USER=1000

--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ DUNE_WALLET_BALANCES_QUERY_ID
 ```
 Refer to `.env.example` for the complete list of supported variables.
 
+The `MAX_TWEETS_PER_USER` setting controls how many tweets are fetched for each
+username. Smaller values reduce API usage and memory footprint.
+
 ## Running the async pipeline
 
 For a lightweight example that works well on machines with limited memory,

--- a/pipelines/tweets.py
+++ b/pipelines/tweets.py
@@ -43,7 +43,7 @@ def iterate_with_retry(client: ApifyClient, dataset_id: str):
             break
 
 USERNAMES = ["onchainlens", "unipcs", "stalkchain", "elonmusk", "example2"]
-MAX_TWEETS_PER_USER = 1000
+MAX_TWEETS_PER_USER = int(get_config("MAX_TWEETS_PER_USER", "1000"))
 HISTORICAL_START = "2017-01-01"
 
 APIFY_TOKEN = get_config("APIFY_TOKEN", "apify_api_xxxxxxxxxx")
@@ -155,7 +155,7 @@ def monitor_costs(client: ApifyClient) -> None:
         logging.warning("Unable to fetch Apify usage info: %s", exc)
 
 
-def iterate_with_retry(
+def iterate_with_retry_func(
     iter_func: Callable[[], Iterable[Any]], *, retries: int = 5, base_backoff: float = 1.0
 ) -> Iterable[Any]:
     """Yield items from ``iter_func`` with simple retry logic."""
@@ -186,7 +186,7 @@ def fetch_tweets(client: ApifyClient, conn: sqlite3.Connection, bot: Bot) -> Non
     except Exception as exc:  # pragma: no cover - best effort logging
         logging.error("Error parsing Apify run result: %s", exc)
         return
-    for item in iterate_with_retry(client, dataset_id):
+    for item in iterate_with_retry_func(lambda: client.dataset(dataset_id).iterate_items()):
         try:
             store_tweet(conn, item)
         except Exception as exc:  # pragma: no cover - best effort logging


### PR DESCRIPTION
## Summary
- make MAX_TWEETS_PER_USER configurable via environment variables
- rename iterate_with_retry helper to avoid conflicts
- document MAX_TWEETS_PER_USER in README
- add variable to `.env.example`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fa1e503d8832bb8fdd93bd912b035