### PR TITLE
Fix duplicate import in extra_pipeline

### DIFF
--- a/extra_pipeline.py
+++ b/extra_pipeline.py
@@ -41,7 +41,6 @@ from lightgbm import LGBMRegressor
 from sklearn.ensemble import VotingRegressor
 import re  # For wallet extraction
 from concurrent.futures import ThreadPoolExecutor, as_completed  # For concurrency
-from config import get_config
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 


### PR DESCRIPTION
## Summary
- remove duplicate `get_config` import in `extra_pipeline.py`

## Testing
- `python -m py_compile extra_pipeline.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687faa239ba8832b9366a0c9c4a96876