### PR TITLE
Fix trailing newline in utils

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -104,4 +104,3 @@ def execute_dune_query(query_id: str, api_key: str, **kwargs: Any) -> List[dict]
     from pipelines.dune import execute_dune_query as _exec
 
     return _exec(query_id, api_key, **kwargs)
-


### PR DESCRIPTION
## Summary
- remove extraneous blank line at end of `utils.py`
- verify module compiles and run flake8

## Testing
- `python -m py_compile utils.py`
- `flake8 utils.py`

------
https://chatgpt.com/codex/tasks/task_e_687faa24693c832bbe8b5a97dcc225dc