### PR TITLE
Add stock options ingestion pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # grok721
 
-This repository contains several example data pipeline scripts. `main.py` provides a minimal workflow that ingests gas prices and tweets. The other modules showcase progressively more complex pipelines and are meant as reference implementations.
+This repository contains several example data pipeline scripts. `main.py` provides a minimal workflow that ingests gas prices, tweets and basic stock option chains. The other modules showcase progressively more complex pipelines and are meant as reference implementations.
 
 ## Pipeline overview
 - `main.py` – basic ingestion example.
@@ -10,6 +10,7 @@ This repository contains several example data pipeline scripts. `main.py` provid
 - `mega_pipeline.py` – **experimental** build with numerous sources.
 - `ultimate_pipeline.py` – **experimental** maximal demonstration.
 - `untrimmed_pipeline.py` – **experimental** raw variant with the full import stack.
+- `ingest_yfinance_options` – helper for storing basic stock option chains.
 
 Additional resources describing the Dune Analytics dashboards referenced by
 the pipelines can be found in [docs/dune_dashboards.md](docs/dune_dashboards.md).

--- a/main.py
+++ b/main.py
@@ -13,6 +13,7 @@ from config import get_config
 from pipelines import init_db
 from pipelines.gas import ingest_gas_prices
 from pipelines.tweets import fetch_tweets
+from pipelines.options import ingest_yfinance_options
 
 APIFY_TOKEN = get_config("APIFY_TOKEN", "apify_api_xxxxxxxxxx")
 TELEGRAM_BOT_TOKEN = get_config("TELEGRAM_BOT_TOKEN", "xxxxxxxxxx:xxxxxxxxxx")
@@ -30,10 +31,15 @@ def main() -> None:
 
         ingest_gas_prices(conn)
         fetch_tweets(client, conn, bot)
+        try:
+            ingest_yfinance_options(conn)
+        except Exception as exc:
+            logging.warning("Options ingestion failed: %s", exc)
 
         scheduler = BackgroundScheduler()
         scheduler.add_job(lambda: fetch_tweets(client, conn, bot), "interval", hours=1)
         scheduler.add_job(lambda: ingest_gas_prices(conn), "interval", hours=6)
+        scheduler.add_job(lambda: ingest_yfinance_options(conn), "interval", hours=24)
         scheduler.start()
 
         logging.info("Scheduler started. Press Ctrl+C to exit.")

--- a/pipelines/__init__.py
+++ b/pipelines/__init__.py
@@ -4,6 +4,7 @@ from .db import init_db
 from .gas import ingest_gas_prices
 from .tweets import fetch_tweets, store_tweet
 from .dune import execute_dune_query, store_dune_rows
+from .options import ingest_yfinance_options
 
 __all__ = [
     "init_db",
@@ -12,4 +13,5 @@ __all__ = [
     "store_tweet",
     "execute_dune_query",
     "store_dune_rows",
+    "ingest_yfinance_options",
 ]

--- a/pipelines/db.py
+++ b/pipelines/db.py
@@ -68,6 +68,22 @@ def init_db(conn: Optional[sqlite3.Connection] = None) -> sqlite3.Connection:
         )
         """
     )
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS stock_options (
+            ticker TEXT,
+            option_type TEXT,
+            expiration TEXT,
+            strike REAL,
+            last_price REAL,
+            implied_vol REAL,
+            open_interest INTEGER,
+            volume INTEGER,
+            fetch_time TEXT,
+            PRIMARY KEY (ticker, option_type, expiration, strike)
+        )
+        """
+    )
     cur.execute("PRAGMA journal_mode=WAL;")
     conn.commit()
     return conn

--- a/pipelines/options.py
+++ b/pipelines/options.py
@@ -1,0 +1,59 @@
+"""Ingest stock options data using yfinance."""
+from __future__ import annotations
+
+import datetime
+import logging
+from typing import Iterable
+
+from config import get_config
+
+try:  # pragma: no cover - optional dependency
+    import yfinance as yf  # type: ignore
+except Exception:  # ModuleNotFoundError during tests
+    yf = None  # type: ignore
+
+YFINANCE_TICKERS = get_config("YFINANCE_TICKERS", "AAPL,TSLA").split(",")
+
+
+def ingest_yfinance_options(conn, tickers: Iterable[str] | None = None) -> None:
+    """Fetch options chains from yfinance and store them in the database."""
+    if yf is None:
+        raise RuntimeError("yfinance package not available")
+    cur = conn.cursor()
+    for ticker in tickers or YFINANCE_TICKERS:
+        try:
+            tk = yf.Ticker(ticker)
+            expirations = getattr(tk, "options", [])
+        except Exception as exc:  # pragma: no cover - best effort logging
+            logging.warning("Failed retrieving options list for %s: %s", ticker, exc)
+            continue
+        for exp in expirations:
+            try:
+                chain = tk.option_chain(exp)
+            except Exception as exc:  # pragma: no cover - best effort logging
+                logging.warning("Failed option chain for %s %s: %s", ticker, exp, exc)
+                continue
+            for opt_type, df in (("call", chain.calls), ("put", chain.puts)):
+                for _, row in df.iterrows():
+                    cur.execute(
+                        """
+                        INSERT OR REPLACE INTO stock_options (
+                            ticker, option_type, expiration, strike,
+                            last_price, implied_vol, open_interest, volume,
+                            fetch_time
+                        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        """,
+                        (
+                            ticker,
+                            opt_type,
+                            exp,
+                            float(row.get("strike", 0)),
+                            float(row.get("lastPrice", 0)),
+                            float(row.get("impliedVolatility", 0)),
+                            int(row.get("openInterest", 0)),
+                            int(row.get("volume", 0)),
+                            datetime.datetime.utcnow().isoformat(),
+                        ),
+                    )
+        conn.commit()
+        logging.info("Ingested options for %s", ticker)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -95,3 +95,10 @@ def db_module(stub_optional_dependencies):
     if 'pipelines.db' in sys.modules:
         return importlib.reload(sys.modules['pipelines.db'])
     return importlib.import_module('pipelines.db')
+
+
+@pytest.fixture
+def options_module(stub_optional_dependencies):
+    if 'pipelines.options' in sys.modules:
+        return importlib.reload(sys.modules['pipelines.options'])
+    return importlib.import_module('pipelines.options')

--- a/tests/test_ingest_yfinance_options.py
+++ b/tests/test_ingest_yfinance_options.py
@@ -1,0 +1,44 @@
+import types
+
+
+def setup_in_memory_db(monkeypatch, db_module):
+    monkeypatch.setattr(db_module, "DB_FILE", ":memory:")
+    return db_module.init_db()
+
+
+class DummyDF:
+    def __init__(self, rows):
+        self.rows = rows
+
+    def iterrows(self):
+        for i, row in enumerate(self.rows):
+            yield i, row
+
+
+class DummyChain:
+    def __init__(self):
+        self.calls = DummyDF([
+            {"strike": 1, "lastPrice": 0.5, "impliedVolatility": 0.2, "openInterest": 10, "volume": 5}
+        ])
+        self.puts = DummyDF([
+            {"strike": 1, "lastPrice": 0.4, "impliedVolatility": 0.3, "openInterest": 8, "volume": 7}
+        ])
+
+
+class DummyTicker:
+    def __init__(self, ticker):
+        self.options = ["2023-01-01"]
+
+    def option_chain(self, exp):
+        return DummyChain()
+
+
+def test_ingest_yfinance_options(monkeypatch, options_module, db_module):
+    conn = setup_in_memory_db(monkeypatch, db_module)
+    monkeypatch.setattr(options_module, "yf", types.SimpleNamespace(Ticker=DummyTicker))
+    options_module.ingest_yfinance_options(conn, ["AAPL"])
+    rows = conn.cursor().execute(
+        "SELECT ticker, option_type, strike FROM stock_options"
+    ).fetchall()
+    assert len(rows) == 2
+    assert {r[1] for r in rows} == {"call", "put"}


### PR DESCRIPTION
## Summary
- support yfinance options ingestion
- create new table for options chains
- expose new helper via package __init__ and wire into `main.py`
- document new ingestion in README
- unit test yfinance options ingestion

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fb3777e38832ba19e657ad3c3bd9f