### PR TITLE
Log SmartAlerts rule exceptions

### DIFF
--- a/smart_alerts.py
+++ b/smart_alerts.py
@@ -7,6 +7,7 @@ check for demonstration."""
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any, Dict, List
+import logging
 
 
 @dataclass
@@ -42,7 +43,9 @@ class SmartAlerts:
                         timestamp=datetime.utcnow(),
                     )
                     triggered.append(alert)
-            except Exception:
-                pass
+            except Exception as exc:
+                logging.exception(
+                    "SmartAlerts rule '%s' raised an exception", rule.get("name")
+                )
         self.alerts.extend(triggered)
         return triggered

--- a/tests/test_smart_alerts.py
+++ b/tests/test_smart_alerts.py
@@ -1,0 +1,18 @@
+import logging
+
+from smart_alerts import SmartAlerts
+
+
+def test_smart_alerts_logs_exceptions(caplog):
+    sa = SmartAlerts()
+
+    def failing_rule(metrics):
+        raise RuntimeError("boom")
+
+    sa.add_rule("fail", failing_rule)
+
+    with caplog.at_level(logging.ERROR):
+        alerts = sa.evaluate({})
+
+    assert alerts == []
+    assert any("fail" in record.getMessage() for record in caplog.records)


### PR DESCRIPTION
## Summary
- add `logging` import to `smart_alerts.py`
- log any raised exceptions in `SmartAlerts.evaluate`
- test exception logging for rules

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6881b432f408832b9b00681a8d29afa6