### PR TITLE
Add resume support to tweet fetch retries

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,6 +53,12 @@ def stub_optional_dependencies():
         requests.post = lambda *a, **k: _resp()
         sys.modules['requests'] = requests
 
+    # psutil
+    if 'psutil' not in sys.modules:
+        psutil = types.ModuleType('psutil')
+        psutil.virtual_memory = lambda: types.SimpleNamespace(available=0)
+        sys.modules['psutil'] = psutil
+
     # If utils was imported before stubbing requests, ensure it uses the stub
     if 'utils' in sys.modules:
         utils = sys.modules['utils']

--- a/tests/test_fetch_tweets.py
+++ b/tests/test_fetch_tweets.py
@@ -12,14 +12,29 @@ class FailingDataset:
         self.items = items
         self.calls = 0
 
-    def iterate_items(self):
+    def iterate_items(self, offset=0):
         self.calls += 1
         if self.calls == 1:
             def gen():
                 raise RuntimeError("boom")
                 yield  # pragma: no cover - never reached
-            return gen()
-        return iter(self.items)
+            yield from gen()
+            return
+        for item in self.items[offset:]:
+            yield item
+
+
+class MidFailDataset:
+    def __init__(self, items):
+        self.items = items
+        self.calls = 0
+
+    def iterate_items(self, offset=0):
+        self.calls += 1
+        for idx in range(offset, len(self.items)):
+            if self.calls == 1 and idx == offset + 1:
+                raise RuntimeError("fail")
+            yield self.items[idx]
 
 
 class DummyClient:
@@ -54,3 +69,26 @@ def test_iterate_with_retry(monkeypatch, tweets_module, db_module):
     rows = conn.cursor().execute("SELECT id FROM tweets").fetchall()
     assert len(rows) == 1
     assert dataset.calls == 2
+
+
+def test_no_duplicates_on_resume(monkeypatch, tweets_module, db_module):
+    conn = setup_in_memory_db(monkeypatch, db_module)
+    items = [
+        {"id": "1", "user": {"username": "alice"}, "created_at": "2023", "text": "hi"},
+        {"id": "2", "user": {"username": "alice"}, "created_at": "2023", "text": "bye"},
+    ]
+    dataset = MidFailDataset(items)
+    client = DummyClient(dataset)
+
+    monkeypatch.setattr(tweets_module, "sentiment_analyzer", lambda text: [{"label": "POSITIVE", "score": 0.5}])
+    monkeypatch.setattr(tweets_module, "monitor_costs", lambda c: None)
+    monkeypatch.setattr(tweets_module, "retry_func", lambda func, *a, **kw: func(*a, **kw))
+    monkeypatch.setattr(tweets_module.time, "sleep", lambda s: None)
+    monkeypatch.setattr(tweets_module, "MAX_TWEETS_PER_USER", 2)
+    monkeypatch.setattr(tweets_module, "USERNAMES", ["alice"])
+
+    tweets_module.fetch_tweets(client, conn, None)
+
+    rows = conn.cursor().execute("SELECT id FROM tweets ORDER BY id").fetchall()
+    assert [r[0] for r in rows] == ["1", "2"]
+    assert dataset.calls >= 2


### PR DESCRIPTION
## Summary
- extend `iterate_with_retry_func` with optional `resume` argument
- resume tweet fetching after failures using dataset offset
- stub psutil in tests
- add regression test for duplicate-free resume logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881b43cd568832b9d5907609d6f2d61