### PR TITLE
Handle sentinel to stop event loop

### DIFF
--- a/tests/test_event_driven.py
+++ b/tests/test_event_driven.py
@@ -1,0 +1,15 @@
+import asyncio
+from event_driven import EventDrivenPipeline
+
+
+def test_start_returns_after_stop_without_events():
+    pipeline = EventDrivenPipeline()
+
+    async def runner():
+        task = asyncio.create_task(pipeline.start())
+        await asyncio.sleep(0.1)
+        await pipeline.stop()
+        await asyncio.wait_for(task, timeout=1)
+        assert task.done()
+
+    asyncio.run(runner())


### PR DESCRIPTION
## Summary
- add sentinel handling for EventBus
- stop the pipeline by publishing `None`
- ensure pipeline start loop exits when sentinel or stop flag triggered
- add unit test for start/stop behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881bc629d24832ba3639b1a8df35773