### PR TITLE
Handle env placeholders in config

### DIFF
--- a/config.py
+++ b/config.py
@@ -38,6 +38,12 @@ def _is_placeholder(value: str) -> bool:
 def get_config(name: str, default: Optional[str] = None) -> str:
     """Retrieve configuration from environment variables."""
     env_value = os.getenv(name)
+    if env_value is not None and _is_placeholder(env_value):
+        warnings.warn(
+            f"Configuration {name} is using a placeholder value: {env_value}",
+            RuntimeWarning,
+        )
+
     value = env_value if env_value is not None else default
     if value is None:
         raise RuntimeError(f"Missing configuration for {name}")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -10,3 +10,10 @@ def test_get_config_warns_for_placeholder(monkeypatch):
         value = config.get_config("PLACEHOLDER_KEY", "xxxxxxxxxx")
     assert value == "xxxxxxxxxx"
 
+
+def test_get_config_warns_for_env_placeholder(monkeypatch):
+    monkeypatch.setenv("PLACEHOLDER_KEY", "xxxxxxxxxx")
+    with pytest.warns(RuntimeWarning):
+        value = config.get_config("PLACEHOLDER_KEY")
+    assert value == "xxxxxxxxxx"
+


### PR DESCRIPTION
## Summary
- warn if environment variable value is a placeholder
- test placeholder warning when value comes from the environment

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881bc62f408832b85cf30238e2ce12b