### PR TITLE
Handle neutral vibe labels

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -27,6 +27,12 @@ def test_compute_vibe_labels(
     assert label == expected_label
 
 
+@pytest.mark.parametrize("sentiment_label", ["NEUTRAL", "UNKNOWN"])
+def test_compute_vibe_neutral_unknown(sentiment_label):
+    score, _ = compute_vibe(sentiment_label, 0.8, 100, 0, 0)
+    assert score == pytest.approx(0.5)
+
+
 @pytest.mark.parametrize(
     "likes,retweets,replies",
     [

--- a/utils.py
+++ b/utils.py
@@ -25,7 +25,12 @@ def compute_vibe(
     has_negative = any(x < 0 for x in (likes, retweets, replies))
 
     engagement = (likes + retweets * 2 + replies) / 1000.0
-    base_score = sentiment_score if sentiment_label == "POSITIVE" else -sentiment_score
+    if sentiment_label == "POSITIVE":
+        base_score = sentiment_score
+    elif sentiment_label == "NEGATIVE":
+        base_score = -sentiment_score
+    else:
+        base_score = 0.0
     vibe_score = (base_score + engagement) * 5
     vibe_score = min(max(vibe_score, 0), 10)
     if vibe_score > 7:


### PR DESCRIPTION
## Summary
- ensure `compute_vibe` doesn't penalize NEUTRAL or unknown sentiment labels
- test that neutral and unknown labels yield an engagement-only score

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881bc62fe88832b8bc42e50322def77