### PR TITLE
Add timeout support to memory scheduler

### DIFF
--- a/ram_optimizer.py
+++ b/ram_optimizer.py
@@ -23,15 +23,22 @@ def run_when_memory_free(
     cmd: List[str],
     min_free_mb: int,
     check_interval: int = 5,
+    timeout: int | None = None,
 ) -> int:
     """Run *cmd* when at least ``min_free_mb`` of memory is free.
 
     The function checks memory usage every ``check_interval`` seconds and
-    blocks until enough memory is available. The command's exit code is
-    returned.
+    blocks until enough memory is available. If ``timeout`` is provided, the
+    wait is limited to at most that many seconds. When the timeout expires the
+    function returns ``1`` without executing the command. The command's exit
+    code is returned when it does run.
     """
+    start = time.time()
     while available_memory_mb() < min_free_mb:
+        if timeout is not None and time.time() - start >= timeout:
+            return 1
         time.sleep(check_interval)
+
     result = subprocess.run(cmd)
     return result.returncode
 

--- a/tests/test_ram_optimizer.py
+++ b/tests/test_ram_optimizer.py
@@ -35,6 +35,33 @@ def test_run_when_memory_free(monkeypatch):
     assert cmd == [["echo", "hi"]]
 
 
+def test_run_when_memory_free_timeout(monkeypatch):
+    calls = []
+
+    monkeypatch.setattr(ram_optimizer, "available_memory_mb", lambda: 100)
+
+    times = [0, 1, 2]
+
+    def fake_time():
+        return times.pop(0)
+
+    monkeypatch.setattr(ram_optimizer.time, "time", fake_time)
+    monkeypatch.setattr(ram_optimizer.time, "sleep", lambda s: calls.append(s))
+
+    monkeypatch.setattr(
+        ram_optimizer.subprocess,
+        "run",
+        lambda c: (_ for _ in ()).throw(AssertionError("command should not run")),
+    )
+
+    rc = ram_optimizer.run_when_memory_free([
+        "echo",
+        "hi",
+    ], 500, check_interval=1, timeout=2)
+    assert rc == 1
+    assert len(calls) == 1
+
+
 def test_schedule_commands(monkeypatch):
     executed = []
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary
- add optional timeout to `run_when_memory_free`
- document new behaviour in docstring
- test timeout behaviour in `tests/test_ram_optimizer.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881bc65bdbc832b9f4d6a89102b4426