### PR TITLE
Update backtesting engine capital tracking

### DIFF
--- a/backtesting_engine.py
+++ b/backtesting_engine.py
@@ -33,6 +33,12 @@ class BacktestingEngine:
         for timestamp, row in data.iterrows():
             signal = strategy.generate_signal(timestamp, row, data.loc[:timestamp])
             if signal and signal.get('action') == 'buy':
-                trade = Trade(timestamp, timestamp, row['close'], row['close'], 'long', 1)
+                entry_price = row.get('open', row['close'])
+                trade = Trade(timestamp, timestamp, entry_price, row['close'], 'long', 1)
                 self.trades.append(trade)
-        return {'trades': len(self.trades)}
+                self.capital += trade.pnl
+        return {
+            'trades': len(self.trades),
+            'final_capital': self.capital,
+            'cumulative_profit': self.capital - self.initial_capital,
+        }

--- a/tests/test_backtesting_engine.py
+++ b/tests/test_backtesting_engine.py
@@ -1,0 +1,22 @@
+import pandas as pd
+from backtesting_engine import BacktestingEngine
+
+class DummyStrategy:
+    def initialize(self):
+        pass
+    def generate_signal(self, ts, row, history):
+        return {'action': 'buy'}
+
+def test_capital_updates_after_trades():
+    data = pd.DataFrame(
+        {
+            'open': [100, 105, 110],
+            'close': [105, 110, 115],
+        },
+        index=pd.date_range('2021-01-01', periods=3, freq='D')
+    )
+    engine = BacktestingEngine(initial_capital=1000)
+    result = engine.run_backtest(DummyStrategy(), data)
+    assert result['trades'] == 3
+    assert result['final_capital'] == 1015
+    assert result['cumulative_profit'] == 15


### PR DESCRIPTION
## Summary
- track realised PnL after each trade in the simple backtesting engine
- expose final capital and cumulative profit to callers
- add a regression test covering the capital accounting

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881bc674a9c832b9adff54eb0c2da27