### PR TITLE
Implement advanced ingestion functions and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository contains several example data pipeline scripts. `main.py` provid
 - `main.py` – basic ingestion example.
 - `async_pipeline.py` – asynchronous variant using `aiohttp`.
 - `extra_pipeline.py` – **experimental** expanded ingestion example.
-- `advanced_pipeline.py` – **experimental** pipeline with many placeholders.
+- `advanced_pipeline.py` – **experimental** pipeline with many placeholders. It now includes basic ingestion helpers for wallets, perps, order books, gas prices and several economic APIs.
 - `mega_pipeline.py` – **experimental** build with numerous sources.
 - `ultimate_pipeline.py` – **experimental** maximal demonstration.
 - `untrimmed_pipeline.py` – **experimental** raw variant with the full import stack.
@@ -92,6 +92,9 @@ DUNE_AIRDROPS_WALLETS_QUERY_ID
 DUNE_SMART_WALLET_FINDER_QUERY_ID
 DUNE_WALLET_BALANCES_QUERY_ID
 ```
+Additional API keys such as `FRED_API_KEY`, `NEWSAPI_KEY`, `OPENEXCHANGE_KEY`,
+`GITHUB_TOKEN` and `QUANDL_KEY` are required when running the advanced
+pipeline.
 The `HISTORICAL_START` variable controls how far back tweets are fetched and
 defaults to `2017-01-01`.
 Refer to `.env.example` for the complete list of supported variables.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,13 @@ def stub_optional_dependencies():
     if 'telegram' not in sys.modules:
         telegram = types.ModuleType('telegram')
         telegram.Bot = lambda token: None
+        ext = types.ModuleType('telegram.ext')
+        ext.Updater = lambda *a, **k: None
+        ext.CallbackQueryHandler = lambda *a, **k: None
+        ext.CommandHandler = lambda *a, **k: None
+        telegram.ext = ext
         sys.modules['telegram'] = telegram
+        sys.modules['telegram.ext'] = ext
 
     # apscheduler background scheduler
     if 'apscheduler.schedulers.background' not in sys.modules:
@@ -52,6 +58,29 @@ def stub_optional_dependencies():
         requests.get = lambda *a, **k: _resp()
         requests.post = lambda *a, **k: _resp()
         sys.modules['requests'] = requests
+
+    # sklearn
+    if 'sklearn' not in sys.modules:
+        skl = types.ModuleType('sklearn')
+        decomposition = types.ModuleType('sklearn.decomposition')
+        class Dummy:
+            def __init__(self, *a, **k):
+                pass
+        decomposition.LatentDirichletAllocation = Dummy
+        feature = types.ModuleType('sklearn.feature_extraction.text')
+        feature.CountVectorizer = Dummy
+        skl.decomposition = decomposition
+        skl.feature_extraction = types.SimpleNamespace(text=feature)
+        sys.modules['sklearn'] = skl
+        sys.modules['sklearn.decomposition'] = decomposition
+        sys.modules['sklearn.feature_extraction'] = types.ModuleType('sklearn.feature_extraction')
+        sys.modules['sklearn.feature_extraction.text'] = feature
+
+    # pandas_gbq
+    if 'pandas_gbq' not in sys.modules:
+        pandas_gbq = types.ModuleType('pandas_gbq')
+        pandas_gbq.read_gbq = lambda *a, **k: []
+        sys.modules['pandas_gbq'] = pandas_gbq
 
     # psutil
     if 'psutil' not in sys.modules:
@@ -108,3 +137,10 @@ def options_module(stub_optional_dependencies):
     if 'pipelines.options' in sys.modules:
         return importlib.reload(sys.modules['pipelines.options'])
     return importlib.import_module('pipelines.options')
+
+
+@pytest.fixture
+def advanced_module(stub_optional_dependencies):
+    if 'advanced_pipeline' in sys.modules:
+        return importlib.reload(sys.modules['advanced_pipeline'])
+    return importlib.import_module('advanced_pipeline')

--- a/tests/test_ingest_alpha_vantage.py
+++ b/tests/test_ingest_alpha_vantage.py
@@ -1,0 +1,32 @@
+import types
+import sqlite3
+import pytest
+
+
+def setup_in_memory_db(monkeypatch: pytest.MonkeyPatch, module):
+    monkeypatch.setattr(module, "DB_FILE", ":memory:")
+    return module.init_db()
+
+
+def test_ingest_alpha_vantage(monkeypatch: pytest.MonkeyPatch, advanced_module, db_module):
+    conn = setup_in_memory_db(monkeypatch, advanced_module)
+
+    monkeypatch.setattr(advanced_module, "ALPHA_ECON_SERIES", ["GDP"])
+    monkeypatch.setattr(advanced_module.time, "sleep", lambda s: None)
+    monkeypatch.setattr(advanced_module, "retry_func", lambda func, *a, **kw: func(*a, **kw))
+
+    def dummy_get(url, *a, **kw):
+        return types.SimpleNamespace(
+            json=lambda: {"data": [{"date": "2023-01-01", "value": "1"}]},
+            raise_for_status=lambda: None,
+        )
+
+    monkeypatch.setattr(advanced_module.requests, "get", dummy_get)
+
+    advanced_module.ingest_alpha_vantage_economic(conn)
+
+    rows = conn.cursor().execute(
+        "SELECT series, date, value, source FROM economic_indicators"
+    ).fetchall()
+
+    assert rows == [("GDP", "2023-01-01", 1.0, "alpha_vantage")]


### PR DESCRIPTION
## Summary
- flesh out advanced ingestion helpers using simple API calls
- stub optional dependencies for tests
- add new unit test for Alpha Vantage ingestion
- document advanced pipeline capabilities and extra environment keys

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68825c77ba3c832b8a5624a6b0028a49